### PR TITLE
Primitive PID tuning (MoveIt!) and FRI port number armonization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,20 @@ For planning (_lwr_moveit_):
 
 ## Usage
 
+## Prerequisites
+- load the script _lwr_hw/krl/ros_control.src_ on the robot  
+- bring the robot in a position where the joints 1 and 3 are as bent as possible (at least 45 degrees) to avoid the "__FRI interpolation error__"  
+- put the robot in __Position__ control  
+- start the script with the grey and green buttons; the scripts stops at a point and should be started again by releasing and pressing again the green button  
+- the script should reach the loop where it wait for commands; now you can proceed by loading the custom controllers or MoveIt!  
+
 ### Custom Controllers
 #### Bringup
 Launch the desired controller and Gazebo to try it out:  
 ``` roslaunch lwr_launch lwr_launch.launch controller:=OneTaskInverseKinematics ```
 
 Use it with a real robot:  
-- load the script _lwr_hw/krl/ros_control.src_  and execute it
-- ```roslaunch lwr_launch lwr_launch.launch controller:=OneTaskInverseKinematics use_lwr_sim:=false ip:=192.168.0.20 port:=49948 ```  
+```roslaunch lwr_launch lwr_launch.launch controller:=OneTaskInverseKinematics use_lwr_sim:=false ip:=192.168.0.20 port:=49939 ```  
 
 #### Motion commands
 Send commands to the controller in another terminal:
@@ -50,5 +56,4 @@ This launch configuration starts a Gazebo simulation that is controlled by MoveI
 `roslaunch lwr_moveit moveit_planning_execution.launch`
 #### Real Robot
 This is how MoveIt! can be connected to a real robot:
-- load the script _lwr_hw/krl/ros_control.src_  and execute it
-- `roslaunch lwr_moveit moveit_planning_execution.launch sim:=false robot_ip:=192.168.0.20 robot_port:=49948`
+- `roslaunch lwr_moveit moveit_planning_execution.launch sim:=false robot_ip:=192.168.0.20 robot_port:=49939`

--- a/ros/kuka_lwr/lwr_hw/launch/lwr_hw.launch
+++ b/ros/kuka_lwr/lwr_hw/launch/lwr_hw.launch
@@ -1,7 +1,7 @@
 <launch>
 
 	<!-- LAUNCH INTERFACE -->
-	<arg name="port" default="49948"/>
+	<arg name="port" default="49939"/>
 	<arg name="ip" default="192.168.0.20"/>
 
 	<!-- LAUNCH IMPLEMENTATION -->

--- a/ros/kuka_lwr/lwr_launch/launch/lwr_launch.launch
+++ b/ros/kuka_lwr/lwr_launch/launch/lwr_launch.launch
@@ -7,7 +7,7 @@
 	<arg name="robot_name" default="lwr_on_box"/>
 	<arg name="use_rviz" default="false"/>
 	<arg name="use_joint_state_publisher" default="true"/>
-	<arg name="port" default="49948"/>
+	<arg name="port" default="49939"/>
 	<arg name="ip" default="192.168.0.20"/>
 
 	<!-- LAUNCH IMPLEMENTATION -->

--- a/ros/kuka_lwr/lwr_moveit/README.md
+++ b/ros/kuka_lwr/lwr_moveit/README.md
@@ -15,6 +15,13 @@ For planning (_lwr_moveit_):
 
 ## Usage
 
+## Prerequisites
+- load the script _lwr_hw/krl/ros_control.src_ on the robot  
+- bring the robot in a position where the joints 1 and 3 are as bent as possible (at least 45 degrees) to avoid the "__FRI interpolation error__"  
+- put the robot in __Position__ control  
+- start the script with the grey and green buttons; the scripts stops at a point and should be started again by releasing and pressing again the green button  
+- the script should reach the loop where it wait for commands; now you can proceed by loading MoveIt!  
+
 ### MoveIt!
 __IMPORTANT__:  This is still an EXPERIMENTAL package! Try it out on real hardware at your own risk, and with the red button next to you.
 #### Demo
@@ -25,5 +32,4 @@ This launch configuration starts a Gazebo simulation that is controlled by MoveI
 `roslaunch lwr_moveit moveit_planning_execution.launch`
 #### Real Robot
 This is how MoveIt! can be connected to a real robot:
-- load the script _lwr_hw/krl/ros_control.src_  and execute it
-- `roslaunch lwr_moveit moveit_planning_execution.launch sim:=false robot_ip:=192.168.0.20 robot_port:=49948`
+- `roslaunch lwr_moveition.launch sim:=false robot_ip:=192.168.0.20 robot_port:=49948`

--- a/ros/kuka_lwr/lwr_moveit/config/joint_limits.yaml
+++ b/ros/kuka_lwr/lwr_moveit/config/joint_limits.yaml
@@ -4,36 +4,36 @@
 joint_limits:
   lwr_0_joint:
     has_velocity_limits: true
-    max_velocity: 1.91986217719
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.5
   lwr_1_joint:
     has_velocity_limits: true
-    max_velocity: 1.91986217719
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.5
   lwr_2_joint:
     has_velocity_limits: true
-    max_velocity: 2.26892802759
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_3_joint:
     has_velocity_limits: true
-    max_velocity: 2.26892802759
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_4_joint:
     has_velocity_limits: true
-    max_velocity: 2.26892802759
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_5_joint:
     has_velocity_limits: true
-    max_velocity: 3.14159265359
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_6_joint:
     has_velocity_limits: true
-    max_velocity: 3.14159265359
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8

--- a/ros/kuka_lwr/lwr_moveit/config/lwr_controller.yaml
+++ b/ros/kuka_lwr/lwr_moveit/config/lwr_controller.yaml
@@ -46,13 +46,13 @@ lwr:
       - lwr_5_joint
       - lwr_6_joint
     gains:
-      lwr_0_joint: {p: 21000,  d: 0, i: 10, i_clamp: 30}
-      lwr_1_joint: {p: 50000,  d: 0, i: 10, i_clamp: 30}
-      lwr_2_joint: {p: 50000,  d: 0, i: 10, i_clamp: 30}
-      lwr_3_joint: {p: 50000,  d: 0, i: 10, i_clamp: 30}
-      lwr_4_joint: {p: 50000,  d: 0, i: 10, i_clamp: 30}
-      lwr_5_joint: {p: 50000,  d: 0, i: 10, i_clamp: 30}
-      lwr_6_joint: {p: 50000,  d: 0, i: 10, i_clamp: 30}
+      lwr_0_joint: {p: 310,  d: 20, i: 0, i_clamp: 30}
+      lwr_1_joint: {p: 300,  d: 10, i: 0, i_clamp: 30}
+      lwr_2_joint: {p: 200,  d: 10, i: 0, i_clamp: 30}
+      lwr_3_joint: {p: 100,  d: 0, i: 0, i_clamp: 30}
+      lwr_4_joint: {p: 200,  d: 0, i: 0, i_clamp: 10}
+      lwr_5_joint: {p: 100,  d: 0, i: 0, i_clamp: 10}
+      lwr_6_joint: {p: 100,  d: 0, i: 0, i_clamp: 0}
 
     constraints:
       goal_time: 0.5                   # Override default

--- a/ros/kuka_lwr/lwr_moveit/config/lwr_controller.yaml
+++ b/ros/kuka_lwr/lwr_moveit/config/lwr_controller.yaml
@@ -46,13 +46,13 @@ lwr:
       - lwr_5_joint
       - lwr_6_joint
     gains:
-      lwr_0_joint: {p: 310,  d: 20, i: 0, i_clamp: 30}
-      lwr_1_joint: {p: 300,  d: 10, i: 0, i_clamp: 30}
-      lwr_2_joint: {p: 200,  d: 10, i: 0, i_clamp: 30}
-      lwr_3_joint: {p: 100,  d: 0, i: 0, i_clamp: 30}
-      lwr_4_joint: {p: 200,  d: 0, i: 0, i_clamp: 10}
-      lwr_5_joint: {p: 100,  d: 0, i: 0, i_clamp: 10}
-      lwr_6_joint: {p: 100,  d: 0, i: 0, i_clamp: 0}
+      lwr_0_joint: {p: 550,  d: 20, i: 40, i_clamp: 30}
+      lwr_1_joint: {p: 400,  d: 10, i: 10, i_clamp: 30}
+      lwr_2_joint: {p: 200,  d: 10, i: 10, i_clamp: 30}
+      lwr_3_joint: {p: 100,  d: 5, i: 10, i_clamp: 30}
+      lwr_4_joint: {p: 80,  d: 3, i: 5, i_clamp: 10}
+      lwr_5_joint: {p: 10,  d: 1, i: 3, i_clamp: 10}
+      lwr_6_joint: {p: 10,  d: 1, i: 3, i_clamp: 10}
 
     constraints:
       goal_time: 0.5                   # Override default

--- a/ros/kuka_lwr/lwr_moveit/launch/moveit_planning_execution.launch
+++ b/ros/kuka_lwr/lwr_moveit/launch/moveit_planning_execution.launch
@@ -13,7 +13,7 @@
   <!--  - if sim=false, a robot_ip argument is required -->
   <arg name="sim" default="true" doc="If true, the robot will be simulated in Gazebo" />
   <arg name="robot_ip" default="192.168.0.20" unless="$(arg sim)" doc="The IP address of the robot" />
-  <arg name="robot_port" default="49948" unless="$(arg sim)" doc="The listening port of the FRI interface" />
+  <arg name="robot_port" default="49939" unless="$(arg sim)" doc="The listening port of the FRI interface" />
  
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find lwr_moveit)/launch/planning_context.launch" >


### PR DESCRIPTION
Hi guys,

I managed to move the robot with MoveIt!, even for quite large movements and with a decent behavior. I guess it would be a nice starting point for more experienced people.

Btw, the port number in the KRL script in the repo is 49939, so I would suggest to use it as a default everywhere.

