### PR TITLE
Update lwr.launch

### DIFF
--- a/lwr_launch/launch/lwr.launch
+++ b/lwr_launch/launch/lwr.launch
@@ -23,7 +23,7 @@
 		</node>
 	</group>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"  />
+	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"  />
 
 	<!-- load controller -->
 	<include file="$(find lwr_controllers)/launch/load_controller.launch">


### PR DESCRIPTION
The deprecated state_publisher node was still there. This fixes it.