### PR TITLE
install gazebo4 in travis.yml and comment vagrant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,19 @@ env:
   - ROS_DISTRO=indigo
 
 before_install:
-  - vagrant status
+  #- vagrant status
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}
   #- codename=`cat /etc/lsb-release | grep -m 1 "DISTRIB_CODENAME=" | cut -d "=" -f2`
   - lsb_release -a
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
   - sudo apt-get update
 
 install:
-  - sudo apt-get install ros-$ROS_DISTRO-desktop-full ros-$ROS_DISTRO-ros-control ros-$ROS_DISTRO-ros-controllers gazebo2 ros-$ROS_DISTRO-gazebo-ros ros-$ROS_DISTRO-gazebo-ros-pkgs 
+  - sudo apt-get install ros-$ROS_DISTRO-desktop-full ros-$ROS_DISTRO-ros-control ros-$ROS_DISTRO-ros-controllers ros-$ROS_DISTRO-gazebo4-ros ros-$ROS_DISTRO-gazebo4-ros-pkgs 
 
 before_script:
   - source /opt/ros/$ROS_DISTRO/setup.bash


### PR DESCRIPTION
Install gazebo4 in the virtual instance.
Comment out vagrant (seems not available yet).

TODO: check out multi-robot-test branch of ros-control?