### PR TITLE
T1 joint limits (optional)

### DIFF
--- a/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
+++ b/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
@@ -11,6 +11,7 @@
 	<arg name="lwr_powered" default="false"/>
 	<arg name="port" default="49939"/>
 	<arg name="ip" default="192.168.0.20"/>
+    <arg name="t1_limits" default="false"/>
 
 	<!-- in case you want to load moveit from here, it might be hard with the real HW though -->
 	<arg name="load_moveit" default="false"/>
@@ -71,6 +72,11 @@
 			<arg name="config" value="true"/>
 			<arg name="debug" value="false"/>
 		</include>
+    </group>
+    
+    <!-- Load updated joint limits (override information from single_lwr_moveit) to respect T1 mode limits -->
+    <group if="$(arg t1_limits)" ns="robot_description_planning">
+        <rosparam command="load" file="$(find single_lwr_robot)/config/t1_joint_limits.yaml"/>
     </group>
 
     <!-- load all controller configurations to rosparam server-->

--- a/single_lwr_example/single_lwr_moveit/config/joint_limits.yaml
+++ b/single_lwr_example/single_lwr_moveit/config/joint_limits.yaml
@@ -4,36 +4,36 @@
 joint_limits:
   lwr_0_joint:
     has_velocity_limits: true
-    max_velocity: 1.91986217719
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.5
   lwr_1_joint:
     has_velocity_limits: true
-    max_velocity: 1.91986217719
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.5
   lwr_2_joint:
     has_velocity_limits: true
-    max_velocity: 2.23402144255
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_3_joint:
     has_velocity_limits: true
-    max_velocity: 2.23402144255
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_4_joint:
     has_velocity_limits: true
-    max_velocity: 3.56047167407
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_5_joint:
     has_velocity_limits: true
-    max_velocity: 3.21140582367
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_6_joint:
     has_velocity_limits: true
-    max_velocity: 3.21140582367
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8

--- a/single_lwr_example/single_lwr_robot/config/t1_joint_limits.yaml
+++ b/single_lwr_example/single_lwr_robot/config/t1_joint_limits.yaml
@@ -4,36 +4,36 @@
 joint_limits:
   lwr_0_joint:
     has_velocity_limits: true
-    max_velocity: 1.91986217719
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.5
   lwr_1_joint:
     has_velocity_limits: true
-    max_velocity: 1.91986217719
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.5
   lwr_2_joint:
     has_velocity_limits: true
-    max_velocity: 2.23402144255
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_3_joint:
     has_velocity_limits: true
-    max_velocity: 2.23402144255
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_4_joint:
     has_velocity_limits: true
-    max_velocity: 3.56047167407
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_5_joint:
     has_velocity_limits: true
-    max_velocity: 3.21140582367
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8
   lwr_6_joint:
     has_velocity_limits: true
-    max_velocity: 3.21140582367
-    has_acceleration_limits: false
-    max_acceleration: 0
+    max_velocity: 0.24
+    has_acceleration_limits: true
+    max_acceleration: 0.8


### PR DESCRIPTION
A parameter can be specified to the launch file to respect the T1 speed and acceleration limits