### PR TITLE
Bring lwr_controllers back to working condition (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ ros/kuka-lwr/lwr_moveit/default_warehouse_mongo_db/local.*
 ros/kuka_lwr/lwr_moveit/default_warehouse_mongo_db/mongod.lock
 ros/kuka_lwr/lwr_moveit/default_warehouse_mongo_db/journal/prealloc.*
 
+*.kdev_include_paths

--- a/lwr_controllers/src/one_task_inverse_kinematics.cpp
+++ b/lwr_controllers/src/one_task_inverse_kinematics.cpp
@@ -86,7 +86,7 @@ namespace lwr_controllers
 		joint_limits_.center.resize(kdl_tree_.getNrOfJoints());
 		int index;
 
-    	for (int i = 0; i < kdl_tree_.getNrOfJoints() && link_; i++)
+    	for (int i = 0; i < kdl_tree_.getNrOfJoints()/2 && link_; i++)
     	{
     		joint_ = model.getJoint(link_->parent_joint->name);  
     		index = kdl_tree_.getNrOfJoints() - i - 1;

--- a/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
+++ b/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
@@ -12,6 +12,7 @@
 	<arg name="port" default="49939"/>
 	<arg name="ip" default="192.168.0.20"/>
     <arg name="t1_limits" default="false"/>
+    <arg name="controllers" default="joint_trajectory_controller stiffness_trajectory_controller"/>
 
 	<!-- in case you want to load moveit from here, it might be hard with the real HW though -->
 	<arg name="load_moveit" default="false"/>
@@ -100,7 +101,7 @@
 		</group>
 
 		<!-- spawn only desired controllers in current namespace -->
-		<node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"  args="joint_state_controller joint_trajectory_controller stiffness_trajectory_controller"/>
+		<node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"  args="joint_state_controller $(arg controllers)"/>
 	</group>
 
 </launch>

--- a/single_lwr_example/single_lwr_moveit/default_warehouse_mongo_db/.gitignore
+++ b/single_lwr_example/single_lwr_moveit/default_warehouse_mongo_db/.gitignore
@@ -1,0 +1,3 @@
+/mongod.lock
+/local.ns
+*.0

--- a/single_lwr_example/single_lwr_robot/config/controllers.yaml
+++ b/single_lwr_example/single_lwr_robot/config/controllers.yaml
@@ -31,7 +31,7 @@ lwr:
   #   Joint Impedance Controllers
   JointImpedanceControl:
     type: lwr_controllers/JointImpedanceController
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
     stiffness_gains: 300
     damping_gains: .7
@@ -39,19 +39,19 @@ lwr:
   # Inverse Dynamics Controllers
   InverseDynamicsControl:
     type: lwr_controllers/InverseDynamicsController
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
 
   # Computed Torque Controllers
   ComputedTorqueControl: 
     type: lwr_controllers/ComputedTorqueController
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
 
   # One Task Inverse Kinematics
   OneTaskInverseKinematics: 
     type: lwr_controllers/OneTaskInverseKinematics
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
     pid_lwr_0_joint: {p: 250,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
     pid_lwr_1_joint: {p: 220,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
@@ -64,7 +64,7 @@ lwr:
   # Multi Task Priority Inverse Kinematics
   MultiTaskPriorityInverseKinematics: 
     type: lwr_controllers/MultiTaskPriorityInverseKinematics
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
     pid_lwr_0_joint: {p: 250,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
     pid_lwr_1_joint: {p: 220,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
@@ -77,35 +77,35 @@ lwr:
   # One Task Inverse Dynamics JL
   OneTaskInverseDynamicsJL: 
     type: lwr_controllers/OneTaskInverseDynamicsJL
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
 
   # Multi Task Priority Inverse Dynamics
   MultiTaskPriorityInverseDynamics: 
     type: lwr_controllers/MultiTaskPriorityInverseDynamics
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
 
   # Minimum Effort Inverse Dynamics
   MinimumEffortInverseDynamics: 
     type: lwr_controllers/MinimumEffortInverseDynamics
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
 
   # Backstepping Controller
   BacksteppingController: 
     type: lwr_controllers/BacksteppingController
-    root_name: box
+    root_name: lwr_base_link
     tip_name: lwr_7_link
 
   # Dynamic Sliding Mode Controller
   DynamicSlidingModeController: 
      type: lwr_controllers/DynamicSlidingModeController
-     root_name: box
+     root_name: lwr_base_link
      tip_name: lwr_7_link
 
   # Dynamic Sliding Mode Controller Task Space
   DynamicSlidingModeControllerTaskSpace: 
      type: lwr_controllers/DynamicSlidingModeControllerTaskSpace
-     root_name: box
+     root_name: lwr_base_link
      tip_name: lwr_7_link

--- a/single_lwr_example/single_lwr_robot/config/controllers.yaml
+++ b/single_lwr_example/single_lwr_robot/config/controllers.yaml
@@ -31,7 +31,7 @@ lwr:
   #   Joint Impedance Controllers
   JointImpedanceControl:
     type: lwr_controllers/JointImpedanceController
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
     stiffness_gains: 300
     damping_gains: .7
@@ -39,19 +39,19 @@ lwr:
   # Inverse Dynamics Controllers
   InverseDynamicsControl:
     type: lwr_controllers/InverseDynamicsController
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
 
   # Computed Torque Controllers
   ComputedTorqueControl: 
     type: lwr_controllers/ComputedTorqueController
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
 
   # One Task Inverse Kinematics
   OneTaskInverseKinematics: 
     type: lwr_controllers/OneTaskInverseKinematics
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
     pid_lwr_0_joint: {p: 250,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
     pid_lwr_1_joint: {p: 220,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
@@ -64,7 +64,7 @@ lwr:
   # Multi Task Priority Inverse Kinematics
   MultiTaskPriorityInverseKinematics: 
     type: lwr_controllers/MultiTaskPriorityInverseKinematics
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
     pid_lwr_0_joint: {p: 250,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
     pid_lwr_1_joint: {p: 220,  i: 10, d: 30, i_clamp_min: -0.3, i_clamp_max: 0.3}
@@ -77,35 +77,35 @@ lwr:
   # One Task Inverse Dynamics JL
   OneTaskInverseDynamicsJL: 
     type: lwr_controllers/OneTaskInverseDynamicsJL
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
 
   # Multi Task Priority Inverse Dynamics
   MultiTaskPriorityInverseDynamics: 
     type: lwr_controllers/MultiTaskPriorityInverseDynamics
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
 
   # Minimum Effort Inverse Dynamics
   MinimumEffortInverseDynamics: 
     type: lwr_controllers/MinimumEffortInverseDynamics
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
 
   # Backstepping Controller
   BacksteppingController: 
     type: lwr_controllers/BacksteppingController
-    root_name: world
+    root_name: box
     tip_name: lwr_7_link
 
   # Dynamic Sliding Mode Controller
   DynamicSlidingModeController: 
      type: lwr_controllers/DynamicSlidingModeController
-     root_name: world
+     root_name: box
      tip_name: lwr_7_link
 
   # Dynamic Sliding Mode Controller Task Space
   DynamicSlidingModeControllerTaskSpace: 
      type: lwr_controllers/DynamicSlidingModeControllerTaskSpace
-     root_name: world
+     root_name: box
      tip_name: lwr_7_link

--- a/single_lwr_example/single_lwr_robot/robot/single_lwr_robot.urdf.xacro
+++ b/single_lwr_example/single_lwr_robot/robot/single_lwr_robot.urdf.xacro
@@ -5,6 +5,12 @@
 	<xacro:include filename="$(find lwr_description)/model/kuka_lwr.urdf.xacro"/>
 
 	<!-- and assemble your robot -->
+    <link name="world" />
+    <joint name="fixed" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="world"/>
+        <child link="box"/>
+    </joint>
 	<link name="box">
 		<inertial>
 			<mass value="5.0"/>

--- a/single_lwr_example/single_lwr_robot/robot/single_lwr_robot.urdf.xacro
+++ b/single_lwr_example/single_lwr_robot/robot/single_lwr_robot.urdf.xacro
@@ -5,12 +5,6 @@
 	<xacro:include filename="$(find lwr_description)/model/kuka_lwr.urdf.xacro"/>
 
 	<!-- and assemble your robot -->
-    <link name="world" />
-    <joint name="fixed" type="fixed">
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <parent link="world"/>
-        <child link="box"/>
-    </joint>
 	<link name="box">
 		<inertial>
 			<mass value="5.0"/>


### PR DESCRIPTION
Changes made:
- OneTaskInverseKinematics: don't rely on kdl_tree_.getNumberOfJoints() because of new stiffness joints in URDF, but divide it by two
- make the kinematic chain start at box instead of world (as it was in old URDF)
- put a fixed joint between world and box, so that the entire robot doesn't wiggle
- restore the controllers argument to single_lwr.launch

Still, the robot doesn't move. What can be missing? Actually I haven't been able to move the robot in Gazebo with lwr_controllers since long before the Merge.