### PR TITLE
Renamed "command_configuration" to "command" topic for lwr_controllers

### DIFF
--- a/lwr_controllers/CMakeLists.txt
+++ b/lwr_controllers/CMakeLists.txt
@@ -25,8 +25,6 @@ add_message_files(
    PoseRPY.msg
    RPY.msg
    MultiPriorityTask.msg
-   PID.msg
-   PIDgains.msg
 )
 
 generate_messages(

--- a/lwr_controllers/README.md
+++ b/lwr_controllers/README.md
@@ -25,24 +25,24 @@ This can be achieved with the _stopped_controllers_ parameter:
 Once the planning environment has loaded, commands can be sent to any joint in another terminal.
 
 - Impedance Controller:
-`rostopic pub -1  /lwr/JointImpedanceControl/command_configuration std_msgs/Float64MultiArray '{ data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}'`
+`rostopic pub -1  /lwr/JointImpedanceControl/command std_msgs/Float64MultiArray '{ data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}'`
 
 - Inverse Dynamics Controller
 `rostopic pub -1  /lwr/InverseDynamicsControl/ext_wrench geometry_msgs/WrenchStamped '{wrench: {force:  {x: 0.0, y: 0.0, z: 0.0}, torque: {x: 0.0,y: 0.0,z: 0.0}}}' `
 
 - Computed Torque Controller:
-`rostopic pub -1  /lwr/ComputedTorqueControl/command_configuration std_msgs/Float64MultiArray '{ data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}'`
+`rostopic pub -1  /lwr/ComputedTorqueControl/command std_msgs/Float64MultiArray '{ data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}'`
 
 - One Task Inverse Kinematics Controller: 
 
   - Full pose (note the IDs)
-`rostopic pub -1  /lwr/OneTaskInverseKinematics/command_configuration lwr_controllers/PoseRPY '{id: 0, position: {x: -0.4, y: 0.3, z: 1.5}, orientation: {roll: 0.1, pitch: 0.2, yaw: 0.0}}'`
+`rostopic pub -1  /lwr/OneTaskInverseKinematics/command lwr_controllers/PoseRPY '{id: 0, position: {x: -0.4, y: 0.3, z: 1.5}, orientation: {roll: 0.1, pitch: 0.2, yaw: 0.0}}'`
 
   - Position only
-`rostopic pub -1  /lwr/OneTaskInverseKinematics/command_configuration lwr_controllers/PoseRPY '{id: 1, position: {x: -0.4, y: 0.3, z: 1.5}}'`
+`rostopic pub -1  /lwr/OneTaskInverseKinematics/command lwr_controllers/PoseRPY '{id: 1, position: {x: -0.4, y: 0.3, z: 1.5}}'`
 
   - Orientation only
-`rostopic pub -1  /lwr/OneTaskInverseKinematics/command_configuration lwr_controllers/PoseRPY '{id: 2, orientation: {roll: 0.1, pitch: 0.2, yaw: 0.0}}'`
+`rostopic pub -1  /lwr/OneTaskInverseKinematics/command lwr_controllers/PoseRPY '{id: 2, orientation: {roll: 0.1, pitch: 0.2, yaw: 0.0}}'`
 
   - PID Gains setting
 `rosrun rqt_reconfigure rqt_reconfigure`
@@ -50,7 +50,7 @@ Once the planning environment has loaded, commands can be sent to any joint in a
 - Multi Task Priority Inverse Kinematics Controller:
   
   - Tasks description (Notes: Link index -1 is EndEffector and Task parameters are [x,y,x,roll,pitch,yaw])
-`rostopic pub -1  /lwr/MultiTaskPriorityInverseKinematics/command_configuration lwr_controllers/MultiPriorityTask '{links: [-1,3], tasks: [-0.4,0.3,1.5,0,0,0,-0.02,0.2,1.311,-1.568,0.291,0.1]}'`
+`rostopic pub -1  /lwr/MultiTaskPriorityInverseKinematics/command lwr_controllers/MultiPriorityTask '{links: [-1,3], tasks: [-0.4,0.3,1.5,0,0,0,-0.02,0.2,1.311,-1.568,0.291,0.1]}'`
 
   - PID Gains setting
 `rosrun rqt_reconfigure rqt_reconfigure`
@@ -58,10 +58,10 @@ Once the planning environment has loaded, commands can be sent to any joint in a
 - Multi Task Priority Inverse Dynamics Controller:
   
   - Tasks description (Notes: Link index -1 is EndEffector and Task parameters are [x,y,x,roll,pitch,yaw])
-`rostopic pub -1  /lwr/MultiTaskPriorityInverseDynamics/command_configuration lwr_controllers/MultiPriorityTask '{links: [-1,3], tasks: [-0.4,0.3,1.5,0,0,0,-0.02,0.2,1.311,-1.568,0.291,0.1]}'`
+`rostopic pub -1  /lwr/MultiTaskPriorityInverseDynamics/command lwr_controllers/MultiPriorityTask '{links: [-1,3], tasks: [-0.4,0.3,1.5,0,0,0,-0.02,0.2,1.311,-1.568,0.291,0.1]}'`
 
 - Dynamic Sliding PID Control (Task Space)
-`rostopic pub -1 /lwr/DynamicSlidingModeControllerTaskSpace/command_configuration std_msgs/Float64MultiArray '{data:[-0.4,0.3,1.5,0,0,0]}'`
+`rostopic pub -1 /lwr/DynamicSlidingModeControllerTaskSpace/command std_msgs/Float64MultiArray '{data:[-0.4,0.3,1.5,0,0,0]}'`
 
 - Minimum Effort Inverse Dynamics Controller:
 just run the controller (no command support)

--- a/lwr_controllers/include/lwr_controllers/backstepping_controller.h
+++ b/lwr_controllers/include/lwr_controllers/backstepping_controller.h
@@ -25,7 +25,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
+		void command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
 		void set_marker(KDL::Frame x, int id);
 
 	private:

--- a/lwr_controllers/include/lwr_controllers/computed_torque_controller.h
+++ b/lwr_controllers/include/lwr_controllers/computed_torque_controller.h
@@ -19,7 +19,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const std_msgs::Float64MultiArray::ConstPtr &msg);
+		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
 		void set_gains(const std_msgs::Float64MultiArray::ConstPtr &msg);
 
 	private:

--- a/lwr_controllers/include/lwr_controllers/dynamic_sliding_mode_controller.h
+++ b/lwr_controllers/include/lwr_controllers/dynamic_sliding_mode_controller.h
@@ -21,7 +21,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const std_msgs::Float64MultiArray::ConstPtr &msg);
+		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
 // 		void set_gains(const std_msgs::Float64MultiArray::ConstPtr &msg);
 		void set_marker(KDL::Frame x, int id);
 

--- a/lwr_controllers/include/lwr_controllers/dynamic_sliding_mode_controller_task_space.h
+++ b/lwr_controllers/include/lwr_controllers/dynamic_sliding_mode_controller_task_space.h
@@ -19,7 +19,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const std_msgs::Float64MultiArray::ConstPtr &msg);
+		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
 		void set_marker(KDL::Frame x, int id);
 
 	private:

--- a/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
+++ b/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
@@ -30,11 +30,9 @@ namespace lwr_controllers
 
 		void update(const ros::Time& time, const ros::Duration& period);
 		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
-		void setGains(const std_msgs::Float64MultiArray::ConstPtr &msg);
 
 	private:
 
-		ros::Subscriber sub_gains_;
 		ros::Subscriber sub_posture_;
 
 		KDL::JntArrayVel dotq_msr_;

--- a/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
+++ b/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
@@ -29,7 +29,7 @@ namespace lwr_controllers
 		void starting(const ros::Time& time);
 
 		void update(const ros::Time& time, const ros::Duration& period);
-		void commandConfiguration(const std_msgs::Float64MultiArray::ConstPtr &msg);
+		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
 		void setGains(const std_msgs::Float64MultiArray::ConstPtr &msg);
 
 	private:

--- a/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
+++ b/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
@@ -30,9 +30,11 @@ namespace lwr_controllers
 
 		void update(const ros::Time& time, const ros::Duration& period);
 		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
+		void setGains(const std_msgs::Float64MultiArray::ConstPtr &msg);
 
 	private:
 
+		ros::Subscriber sub_gains_;
 		ros::Subscriber sub_posture_;
 
 		KDL::JntArrayVel dotq_msr_;

--- a/lwr_controllers/include/lwr_controllers/minimum_effort_inverse_dynamics.h
+++ b/lwr_controllers/include/lwr_controllers/minimum_effort_inverse_dynamics.h
@@ -27,7 +27,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
+		void command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
 		void set_marker(KDL::Frame x, int id);
 
 	private:

--- a/lwr_controllers/include/lwr_controllers/multi_task_priority_inverse_dynamics.h
+++ b/lwr_controllers/include/lwr_controllers/multi_task_priority_inverse_dynamics.h
@@ -21,7 +21,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
+		void command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
 		void set_marker(KDL::Frame x, int index, int id);
 
 	private:

--- a/lwr_controllers/include/lwr_controllers/multi_task_priority_inverse_kinematics.h
+++ b/lwr_controllers/include/lwr_controllers/multi_task_priority_inverse_kinematics.h
@@ -21,7 +21,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
+		void command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg);
 		void set_marker(KDL::Frame x, int index, int id);
 
 	private:

--- a/lwr_controllers/include/lwr_controllers/one_task_inverse_dynamics_jl.h
+++ b/lwr_controllers/include/lwr_controllers/one_task_inverse_dynamics_jl.h
@@ -23,7 +23,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const lwr_controllers::PoseRPY::ConstPtr &msg);
+		void command(const lwr_controllers::PoseRPY::ConstPtr &msg);
 		void set_marker(KDL::Frame x, int id);
 		double task_objective_function(KDL::JntArray q);
 

--- a/lwr_controllers/include/lwr_controllers/one_task_inverse_kinematics.h
+++ b/lwr_controllers/include/lwr_controllers/one_task_inverse_kinematics.h
@@ -30,7 +30,7 @@ namespace lwr_controllers
 		bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 		void starting(const ros::Time& time);
 		void update(const ros::Time& time, const ros::Duration& period);
-		void command_configuration(const lwr_controllers::PoseRPY::ConstPtr &msg);
+		void command(const lwr_controllers::PoseRPY::ConstPtr &msg);
 
 	private:
 		ros::Subscriber sub_command_;

--- a/lwr_controllers/msg/PID.msg
+++ b/lwr_controllers/msg/PID.msg
@@ -1,3 +1,0 @@
-float64 p
-float64 i
-float64 d

--- a/lwr_controllers/msg/PIDgains.msg
+++ b/lwr_controllers/msg/PIDgains.msg
@@ -1,9 +1,0 @@
-#include <lwr_controllers/PID.h>
-
-PID lwr_0_joint
-PID lwr_1_joint
-PID lwr_2_joint
-PID lwr_3_joint
-PID lwr_4_joint
-PID lwr_5_joint
-PID lwr_6_joint

--- a/lwr_controllers/src/backstepping_controller.cpp
+++ b/lwr_controllers/src/backstepping_controller.cpp
@@ -30,7 +30,7 @@ namespace lwr_controllers
 		C_.resize(kdl_chain_.getNrOfJoints());
 		G_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &BacksteppingController::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &BacksteppingController::command, this);
 
 		pub_error_ = nh_.advertise<std_msgs::Float64MultiArray>("error", 1000);
 		pub_pose_ = nh_.advertise<std_msgs::Float64MultiArray>("pose", 1000);
@@ -196,7 +196,7 @@ namespace lwr_controllers
 
 	}
 
-	void BacksteppingController::command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
+	void BacksteppingController::command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
 	{
 		step_ = 0;
 		first_step_ = 1;

--- a/lwr_controllers/src/computed_torque_controller.cpp
+++ b/lwr_controllers/src/computed_torque_controller.cpp
@@ -23,7 +23,7 @@ namespace lwr_controllers
 		C_.resize(kdl_chain_.getNrOfJoints());
 		G_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_posture_ = nh_.subscribe("command_configuration", 1, &ComputedTorqueController::command_configuration, this);
+		sub_posture_ = nh_.subscribe("command", 1, &ComputedTorqueController::command, this);
 		sub_gains_ = nh_.subscribe("set_gains", 1, &ComputedTorqueController::set_gains, this);
 
 		return true;		
@@ -95,7 +95,7 @@ namespace lwr_controllers
 
     }
 
-    void ComputedTorqueController::command_configuration(const std_msgs::Float64MultiArray::ConstPtr &msg)
+    void ComputedTorqueController::command(const std_msgs::Float64MultiArray::ConstPtr &msg)
     {
     	if(msg->data.size() == 0)
     		ROS_INFO("Desired configuration must be of dimension %lu", joint_handles_.size());

--- a/lwr_controllers/src/dynamic_sliding_mode_controller.cpp
+++ b/lwr_controllers/src/dynamic_sliding_mode_controller.cpp
@@ -40,7 +40,7 @@ namespace lwr_controllers
 		lambda_.resize(kdl_chain_.getNrOfJoints());
 		k_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &DynamicSlidingModeController::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &DynamicSlidingModeController::command, this);
 // 		sub_gains_ = nh_.subscribe("set_gains", 1, &DynamicSlidingModeController::set_gains, this);
 
 		pub_error_ = nh_.advertise<std_msgs::Float64MultiArray>("error", 1000);
@@ -159,7 +159,7 @@ namespace lwr_controllers
 
 	}
 
-	void DynamicSlidingModeController::command_configuration(const std_msgs::Float64MultiArray::ConstPtr &msg)
+	void DynamicSlidingModeController::command(const std_msgs::Float64MultiArray::ConstPtr &msg)
 	{
 
 	}

--- a/lwr_controllers/src/dynamic_sliding_mode_controller_task_space.cpp
+++ b/lwr_controllers/src/dynamic_sliding_mode_controller_task_space.cpp
@@ -41,7 +41,7 @@ namespace lwr_controllers
 		lambda_.resize(kdl_chain_.getNrOfJoints());
 		k_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &DynamicSlidingModeControllerTaskSpace::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &DynamicSlidingModeControllerTaskSpace::command, this);
 
 		pub_error_ = nh_.advertise<std_msgs::Float64MultiArray>("error", 1000);
 		pub_pose_ = nh_.advertise<std_msgs::Float64MultiArray>("pose", 1000);
@@ -196,7 +196,7 @@ namespace lwr_controllers
 
 	}
 
-	void DynamicSlidingModeControllerTaskSpace::command_configuration(const std_msgs::Float64MultiArray::ConstPtr &msg)
+	void DynamicSlidingModeControllerTaskSpace::command(const std_msgs::Float64MultiArray::ConstPtr &msg)
 	{
 		if (msg->data.size() == 6)
 		{

--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -48,7 +48,7 @@ bool JointImpedanceController::init(hardware_interface::EffortJointInterface *ro
   // D_.resize(kdl_chain_.getNrOfJoints());
 
   sub_gains_ = nh_.subscribe("gains", 1, &JointImpedanceController::setGains, this);
-  sub_posture_ = nh_.subscribe("command_configuration", 1, &JointImpedanceController::commandConfiguration, this);
+  sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::commandConfiguration, this);
 
 
   return true;

--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -48,7 +48,7 @@ bool JointImpedanceController::init(hardware_interface::EffortJointInterface *ro
   // D_.resize(kdl_chain_.getNrOfJoints());
 
   sub_gains_ = nh_.subscribe("gains", 1, &JointImpedanceController::setGains, this);
-  sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::commandConfiguration, this);
+  sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::command, this);
 
 
   return true;

--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -47,7 +47,6 @@ bool JointImpedanceController::init(hardware_interface::EffortJointInterface *ro
   // K_.resize(kdl_chain_.getNrOfJoints());
   // D_.resize(kdl_chain_.getNrOfJoints());
 
-  sub_gains_ = nh_.subscribe("gains", 1, &JointImpedanceController::setGains, this);
   sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::command, this);
 
 
@@ -91,7 +90,7 @@ void JointImpedanceController::update(const ros::Time& time, const ros::Duration
 }
 
 
-void JointImpedanceController::commandConfiguration(const std_msgs::Float64MultiArray::ConstPtr &msg){
+void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstPtr &msg){
   if (msg->data.size() == 0) {
     ROS_INFO("Desired configuration must be: %lu dimension", joint_handles_.size());
     }
@@ -105,32 +104,8 @@ void JointImpedanceController::commandConfiguration(const std_msgs::Float64Multi
     q_des_(j) = msg->data[j];
   }
 
-  }
+}
 
-void JointImpedanceController::setGains(const std_msgs::Float64MultiArray::ConstPtr &msg){
-
-  if (msg->data.size() == 2*joint_handles_.size()){
-    for (unsigned int i = 0; i < joint_handles_.size(); ++i){
-      K_(i) = msg->data[i];
-      D_(i)= msg->data[i + joint_handles_.size()];
-      }
-    // for (unsigned int i = joint_handles_.size(); i < 2*joint_handles_.size(); ++i){
-      // 	D_(i)= msg->data[i];
-      // }
-    }
-  else
-  {
-    ROS_INFO("Num of Joint handles = %lu", joint_handles_.size());
-  }
-
-  ROS_INFO("Num of Joint handles = %lu, dimension of message = %lu", joint_handles_.size(), msg->data.size());
-
-  ROS_INFO("New gains K: %.1lf, %.1lf, %.1lf %.1lf, %.1lf, %.1lf, %.1lf",
-  K_(0), K_(1), K_(2), K_(3), K_(4), K_(5), K_(6));
-  ROS_INFO("New gains D: %.1lf, %.1lf, %.1lf %.1lf, %.1lf, %.1lf, %.1lf",
-  D_(0), D_(1), D_(2), D_(3), D_(4), D_(5), D_(6));
-
-  }
 
 
 }                                                           // namespace

--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -47,6 +47,7 @@ bool JointImpedanceController::init(hardware_interface::EffortJointInterface *ro
   // K_.resize(kdl_chain_.getNrOfJoints());
   // D_.resize(kdl_chain_.getNrOfJoints());
 
+  sub_gains_ = nh_.subscribe("gains", 1, &JointImpedanceController::setGains, this);
   sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::command, this);
 
 
@@ -90,7 +91,7 @@ void JointImpedanceController::update(const ros::Time& time, const ros::Duration
 }
 
 
-void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstPtr &msg){
+void JointImpedanceController::commandConfiguration(const std_msgs::Float64MultiArray::ConstPtr &msg){
   if (msg->data.size() == 0) {
     ROS_INFO("Desired configuration must be: %lu dimension", joint_handles_.size());
     }
@@ -104,8 +105,32 @@ void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstP
     q_des_(j) = msg->data[j];
   }
 
-}
+  }
 
+void JointImpedanceController::setGains(const std_msgs::Float64MultiArray::ConstPtr &msg){
+
+  if (msg->data.size() == 2*joint_handles_.size()){
+    for (unsigned int i = 0; i < joint_handles_.size(); ++i){
+      K_(i) = msg->data[i];
+      D_(i)= msg->data[i + joint_handles_.size()];
+      }
+    // for (unsigned int i = joint_handles_.size(); i < 2*joint_handles_.size(); ++i){
+      // 	D_(i)= msg->data[i];
+      // }
+    }
+  else
+  {
+    ROS_INFO("Num of Joint handles = %lu", joint_handles_.size());
+  }
+
+  ROS_INFO("Num of Joint handles = %lu, dimension of message = %lu", joint_handles_.size(), msg->data.size());
+
+  ROS_INFO("New gains K: %.1lf, %.1lf, %.1lf %.1lf, %.1lf, %.1lf, %.1lf",
+  K_(0), K_(1), K_(2), K_(3), K_(4), K_(5), K_(6));
+  ROS_INFO("New gains D: %.1lf, %.1lf, %.1lf %.1lf, %.1lf, %.1lf, %.1lf",
+  D_(0), D_(1), D_(2), D_(3), D_(4), D_(5), D_(6));
+
+  }
 
 
 }                                                           // namespace

--- a/lwr_controllers/src/minimum_effort_inverse_dynamics.cpp
+++ b/lwr_controllers/src/minimum_effort_inverse_dynamics.cpp
@@ -29,7 +29,7 @@ namespace lwr_controllers
 		C_.resize(kdl_chain_.getNrOfJoints());
 		G_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &MinimumEffortInverseDynamics::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &MinimumEffortInverseDynamics::command, this);
 
 		pub_error_ = nh_.advertise<std_msgs::Float64MultiArray>("error", 1000);
 		pub_pose_ = nh_.advertise<std_msgs::Float64MultiArray>("pose", 1000);
@@ -195,7 +195,7 @@ namespace lwr_controllers
 
 	}
 
-	void MinimumEffortInverseDynamics::command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
+	void MinimumEffortInverseDynamics::command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
 	{
 		first_step_ = 1;
 		cmd_flag_ = 1;	

--- a/lwr_controllers/src/multi_task_priority_inverse_dynamics.cpp
+++ b/lwr_controllers/src/multi_task_priority_inverse_dynamics.cpp
@@ -30,7 +30,7 @@ namespace lwr_controllers
 		C_.resize(kdl_chain_.getNrOfJoints());
 		G_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &MultiTaskPriorityInverseDynamics::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &MultiTaskPriorityInverseDynamics::command, this);
 
 		pub_error_ = nh_.advertise<std_msgs::Float64MultiArray>("error", 1000);
 		pub_marker_ = nh_.advertise<visualization_msgs::MarkerArray>("marker",1000);
@@ -171,7 +171,7 @@ namespace lwr_controllers
 
 	}
 
-	void MultiTaskPriorityInverseDynamics::command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
+	void MultiTaskPriorityInverseDynamics::command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
 	{
 		if (msg->links.size() == msg->tasks.size()/6)
 		{

--- a/lwr_controllers/src/multi_task_priority_inverse_kinematics.cpp
+++ b/lwr_controllers/src/multi_task_priority_inverse_kinematics.cpp
@@ -23,7 +23,7 @@ namespace lwr_controllers
 		J_.resize(kdl_chain_.getNrOfJoints());
 		J_star_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &MultiTaskPriorityInverseKinematics::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &MultiTaskPriorityInverseKinematics::command, this);
 
 		pub_error_ = nh_.advertise<std_msgs::Float64MultiArray>("error", 1000);
 		pub_marker_ = nh_.advertise<visualization_msgs::MarkerArray>("marker",1000);
@@ -132,7 +132,7 @@ namespace lwr_controllers
 
 	}
 
-	void MultiTaskPriorityInverseKinematics::command_configuration(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
+	void MultiTaskPriorityInverseKinematics::command(const lwr_controllers::MultiPriorityTask::ConstPtr &msg)
 	{
 		if (msg->links.size() == msg->tasks.size()/6)
 		{

--- a/lwr_controllers/src/one_task_inverse_dynamics_jl.cpp
+++ b/lwr_controllers/src/one_task_inverse_dynamics_jl.cpp
@@ -34,7 +34,7 @@ namespace lwr_controllers
 
 		J_last_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &OneTaskInverseDynamicsJL::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &OneTaskInverseDynamicsJL::command, this);
 		pub_error_ = nh_.advertise<std_msgs::Float64MultiArray>("error", 1000);
 		pub_pose_ = nh_.advertise<std_msgs::Float64MultiArray>("pose", 1000);
 		pub_marker_ = nh_.advertise<visualization_msgs::Marker>("marker",1000);
@@ -184,7 +184,7 @@ namespace lwr_controllers
 
 	}
 
-	void OneTaskInverseDynamicsJL::command_configuration(const lwr_controllers::PoseRPY::ConstPtr &msg)
+	void OneTaskInverseDynamicsJL::command(const lwr_controllers::PoseRPY::ConstPtr &msg)
 	{	
 		KDL::Frame frame_des_;
 

--- a/lwr_controllers/src/one_task_inverse_kinematics.cpp
+++ b/lwr_controllers/src/one_task_inverse_kinematics.cpp
@@ -27,7 +27,7 @@ namespace lwr_controllers
 		tau_cmd_.resize(kdl_chain_.getNrOfJoints());
 		J_.resize(kdl_chain_.getNrOfJoints());
 
-		sub_command_ = nh_.subscribe("command_configuration", 1, &OneTaskInverseKinematics::command_configuration, this);
+		sub_command_ = nh_.subscribe("command", 1, &OneTaskInverseKinematics::command, this);
 
 		return true;
 	}
@@ -127,7 +127,7 @@ namespace lwr_controllers
     	}
 	}
 
-	void OneTaskInverseKinematics::command_configuration(const lwr_controllers::PoseRPY::ConstPtr &msg)
+	void OneTaskInverseKinematics::command(const lwr_controllers::PoseRPY::ConstPtr &msg)
 	{	
 		KDL::Frame frame_des_;
 


### PR DESCRIPTION
Next I would unify the API to accept a cartesian position as geometry_msgs::Pose.
Is there any particular reason why some controllers take a PoseRPY?

Of course the multi-task algorithms should stay as they are since there is no standard algorithm.