### PR TITLE
Use more precise type for joint_handles in KinematicChain base

### DIFF
--- a/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
+++ b/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
@@ -46,7 +46,7 @@ namespace controller_interface
 			KDL::JntArray center;
 		} joint_limits_;
 
-		std::vector<hardware_interface::JointHandle> joint_handles_;
+		std::vector<typename JI::ResourceHandleType> joint_handles_;
 	};
     
     template <typename JI>


### PR DESCRIPTION
Very small detail - but is more correct.

The joint handles will be PositionJointHandles for KinematicChainControllerBase<PositionJointInterface>, and so on.