### PR TITLE
External torque estimation, URDF refining

### DIFF
--- a/lwr_controllers/CMakeLists.txt
+++ b/lwr_controllers/CMakeLists.txt
@@ -23,6 +23,7 @@ add_message_files(
    PoseRPY.msg
    RPY.msg
    MultiPriorityTask.msg
+   ArmState.msg
 )
 
 generate_messages(

--- a/lwr_controllers/CMakeLists.txt
+++ b/lwr_controllers/CMakeLists.txt
@@ -4,6 +4,7 @@ project(lwr_controllers)
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
   control_msgs
+  geometry_msgs
   forward_command_controller
   control_toolbox
   realtime_tools
@@ -12,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   kdl_parser
   message_generation
   cmake_modules
+  kdl_conversions
 )
 
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
@@ -36,6 +38,7 @@ catkin_package(
   CATKIN_DEPENDS
     controller_interface
     control_msgs
+    geometry_msgs
     control_toolbox
     realtime_tools
     urdf

--- a/lwr_controllers/CMakeLists.txt
+++ b/lwr_controllers/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(${PROJECT_NAME}
   src/dynamic_sliding_mode_controller_task_space.cpp
   src/one_task_inverse_dynamics_jl.cpp
   src/gravity_compensation.cpp
+  src/arm_state_controller.cpp
 )
 
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp)

--- a/lwr_controllers/include/lwr_controllers/arm_state_controller.h
+++ b/lwr_controllers/include/lwr_controllers/arm_state_controller.h
@@ -3,8 +3,12 @@
 
 #include "KinematicChainControllerBase.h"
 
-#include <std_msgs/Bool.h>
+#include <lwr_controllers/ArmState.h>
 #include <std_msgs/Float32.h>
+#include <std_msgs/Bool.h>
+
+#include <realtime_tools/realtime_publisher.h>
+
 #include <boost/scoped_ptr.hpp>
 
 namespace arm_state_controller
@@ -23,7 +27,7 @@ namespace arm_state_controller
         
     private:
                 
-        boost::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::JointState> > realtime_pub_;
+        boost::shared_ptr< realtime_tools::RealtimePublisher< lwr_controllers::ArmState > > realtime_pub_;
         
         boost::scoped_ptr<KDL::ChainIdSolver_RNE> id_solver_;
         boost::scoped_ptr<KDL::Vector> gravity_;

--- a/lwr_controllers/include/lwr_controllers/arm_state_controller.h
+++ b/lwr_controllers/include/lwr_controllers/arm_state_controller.h
@@ -30,6 +30,8 @@ namespace arm_state_controller
         boost::shared_ptr< realtime_tools::RealtimePublisher< lwr_controllers::ArmState > > realtime_pub_;
         
         boost::scoped_ptr<KDL::ChainIdSolver_RNE> id_solver_;
+        boost::scoped_ptr<KDL::ChainJntToJacSolver> jac_solver_;
+        boost::scoped_ptr<KDL::Jacobian> jacobian_;
         boost::scoped_ptr<KDL::Vector> gravity_;
         boost::scoped_ptr<KDL::JntArray> joint_position_;
         boost::scoped_ptr<KDL::JntArray> joint_velocity_;
@@ -39,7 +41,6 @@ namespace arm_state_controller
         
         ros::Time last_publish_time_;
         double publish_rate_;
-        
     };
 }
 

--- a/lwr_controllers/include/lwr_controllers/arm_state_controller.h
+++ b/lwr_controllers/include/lwr_controllers/arm_state_controller.h
@@ -1,0 +1,42 @@
+#ifndef ARM_STATE_CONTROLLER_H
+#define ARM_STATE_CONTROLLER_H
+
+#include "KinematicChainControllerBase.h"
+
+#include <std_msgs/Bool.h>
+#include <std_msgs/Float32.h>
+#include <boost/scoped_ptr.hpp>
+
+namespace arm_state_controller
+{
+    class ArmStateController: public controller_interface::KinematicChainControllerBase<hardware_interface::JointStateInterface>
+    {
+    public:
+        
+        ArmStateController();
+        ~ArmStateController();
+        
+        bool init(hardware_interface::JointStateInterface *robot, ros::NodeHandle &n);
+        void starting(const ros::Time& time);
+        void update(const ros::Time& time, const ros::Duration& period);
+        void stopping(const ros::Time& time);
+        
+    private:
+                
+        boost::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::JointState> > realtime_pub_;
+        
+        boost::scoped_ptr<KDL::ChainIdSolver_RNE> id_solver_;
+        boost::scoped_ptr<KDL::Vector> gravity_;
+        boost::scoped_ptr<KDL::JntArray> joint_position_;
+        boost::scoped_ptr<KDL::JntArray> joint_velocity_;
+        boost::scoped_ptr<KDL::JntArray> joint_acceleration_;
+        boost::scoped_ptr<KDL::Wrenches> joint_wrenches_;
+        boost::scoped_ptr<KDL::JntArray> joint_effort_est_;
+        
+        ros::Time last_publish_time_;
+        double publish_rate_;
+        
+    };
+}
+
+#endif

--- a/lwr_controllers/include/lwr_controllers/arm_state_controller.h
+++ b/lwr_controllers/include/lwr_controllers/arm_state_controller.h
@@ -31,6 +31,7 @@ namespace arm_state_controller
         
         boost::scoped_ptr<KDL::ChainIdSolver_RNE> id_solver_;
         boost::scoped_ptr<KDL::ChainJntToJacSolver> jac_solver_;
+        boost::scoped_ptr<KDL::ChainFkSolverPos> fk_solver_;
         boost::scoped_ptr<KDL::Jacobian> jacobian_;
         boost::scoped_ptr<KDL::Vector> gravity_;
         boost::scoped_ptr<KDL::JntArray> joint_position_;

--- a/lwr_controllers/include/lwr_controllers/gravity_compensation.h
+++ b/lwr_controllers/include/lwr_controllers/gravity_compensation.h
@@ -27,7 +27,7 @@ namespace lwr_controllers
         // hack required as long as there is separate position handle for stiffness
         std::vector<hardware_interface::JointHandle> joint_stiffness_handles_;
         
-        const static float DEFAULT_STIFFNESS = 0.01;
+        constexpr static float DEFAULT_STIFFNESS = 0.01;
         
     };
 }

--- a/lwr_controllers/lwr_controllers_plugins.xml
+++ b/lwr_controllers/lwr_controllers_plugins.xml
@@ -1,5 +1,11 @@
 <library path="lib/liblwr_controllers">
-    
+  
+  <class name="arm_state_controller/ArmStateController" type="arm_state_controller::ArmStateController" base_class_type="controller_interface::ControllerBase">
+    <description>
+      Information about external torque, Jacobian, etc.
+    </description>
+  </class>
+  
   <class name="lwr_controllers/GravityCompensation" type="lwr_controllers::GravityCompensation" base_class_type="controller_interface::ControllerBase">
     <description>
       Safe gravity compensation.

--- a/lwr_controllers/msg/ArmState.msg
+++ b/lwr_controllers/msg/ArmState.msg
@@ -3,3 +3,4 @@ Header header
 string[] joint_name
 float32[] est_ext_torques
 geometry_msgs/Wrench est_ee_wrench
+geometry_msgs/Wrench est_ee_wrench_base

--- a/lwr_controllers/msg/ArmState.msg
+++ b/lwr_controllers/msg/ArmState.msg
@@ -1,0 +1,7 @@
+Header header
+
+string[] joint_name
+float32[] est_ext_torques
+
+# TODO
+# - cartesian force on end effector?

--- a/lwr_controllers/msg/ArmState.msg
+++ b/lwr_controllers/msg/ArmState.msg
@@ -2,6 +2,4 @@ Header header
 
 string[] joint_name
 float32[] est_ext_torques
-
-# TODO
-# - cartesian force on end effector?
+geometry_msgs/Wrench est_ee_wrench

--- a/lwr_controllers/package.xml
+++ b/lwr_controllers/package.xml
@@ -13,7 +13,8 @@
 
   <build_depend>angles</build_depend>
   <build_depend>controller_interface</build_depend> 
-  <build_depend>control_msgs</build_depend> 
+  <build_depend>control_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend> 
   <build_depend>control_toolbox</build_depend> 
   <build_depend>realtime_tools</build_depend> 
   <build_depend>urdf</build_depend> 
@@ -25,7 +26,8 @@
 
   <run_depend>angles</run_depend>
   <run_depend>controller_interface</run_depend> 
-  <run_depend>control_msgs</run_depend> 
+  <run_depend>control_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend> 
   <run_depend>control_toolbox</run_depend> 
   <run_depend>realtime_tools</run_depend> 
   <run_depend>urdf</run_depend> 

--- a/lwr_controllers/src/arm_state_controller.cpp
+++ b/lwr_controllers/src/arm_state_controller.cpp
@@ -1,0 +1,97 @@
+#include <pluginlib/class_list_macros.h>
+#include <math.h>
+
+#include <lwr_controllers/arm_state_controller.h>
+
+namespace arm_state_controller  
+{
+    ArmStateController::ArmStateController() {}
+    ArmStateController::~ArmStateController() {}
+    
+    bool ArmStateController::init(hardware_interface::JointStateInterface *robot, ros::NodeHandle &n)
+    {
+        KinematicChainControllerBase<hardware_interface::JointStateInterface>::init(robot, n);
+        
+        // TODO: parse urdf for link mass, inertia, etc.
+        
+        // TODO: new realtime publisher
+        
+        gravity_.reset(new KDL::Vector(0.0, 0.0, -9.81)); // TODO: compute from actual robot position (TF?)
+        id_solver_.reset(new KDL::ChainIdSolver_RNE(kdl_chain_, gravity_));
+        joint_position_.reset(new KDL::JntArray(kdl_chain_.getNrOfJoints());
+        joint_velocity_.reset(new KDL::JntArray(kdl_chain_.getNrOfJoints());
+        joint_acceleration_.reset(new KDL::JntArray(kdl_chain_.getNrOfJoints());
+        joint_wrenches_.reset(new KDL::Wrenches);
+        joint_effort_est_.reset(new KDL::JntArray(kdl_chain_.getNrOfJoints());
+        
+        for (unsigned i = 0; i < joint_handles_.size(); i++){
+            joint_wrenches_->push_back(KDL::Wrench);
+        }
+        
+        return true;		
+    }
+    
+    void ArmStateController::starting(const ros::Time& time)
+    {
+        last_publish_time_ = time;
+        for (unsigned i = 0; i < joint_handles_.size(); i++){
+            joint_position_[i] = joint_handles_[i].getPosition();
+            joint_velocity_[i] = joint_handles_[i].getVelocity();
+            joint_acceleration_[i] = 0; 
+        }
+    }
+    
+    void ArmStateController::update(const ros::Time& time, const ros::Duration& period)
+    {
+        // TODO: compute gravity force on robot from joint state and urdf data
+        
+        // TODO: copied from JointStateController, adjust
+        // limit rate of publishing
+        if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0/publish_rate_) < time){
+            
+            // try to publish
+            if (realtime_pub_->trylock()){
+                // we're actually publishing, so increment time
+                last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
+                
+                for (unsigned i = 0; i < joint_handles_.size(); i++){
+                    joint_position_[i] = joint_handles_[i].getPosition();
+                    joint_velocity_[i] = joint_handles_[i].getVelocity();
+                    joint_acceleration_[i] = 0;  // TODO: compute from previous velocity?
+                }
+                
+                // Compute Dynamics 
+                int ret = id_solver_->CartToJnt(*joint_position_, 
+                                                *joint_velocity_, 
+                                                *joint_acceleration_, 
+                                                *joint_wrenches_,
+                                                *joint_effort_est_);
+                if (ret < 0) { 
+                    ROS_ERROR("KDL: inverse dynamics ERROR");
+                    realtime_pub_->unlock();
+                    return;
+                }
+                
+                // populate joint state message
+                realtime_pub_->msg_.header.stamp = time;
+                for (unsigned i=0; i<joint_handles_.size(); i++){
+                    realtime_pub_->msg_.position[i] = joint_handles_[i].getPosition();
+                    realtime_pub_->msg_.velocity[i] = joint_handles_[i].getVelocity();
+                    realtime_pub_->msg_.effort[i] = joint_handles_[i].getEffort();
+                }
+                realtime_pub_->unlockAndPublish();
+            }
+        }   
+    }
+    
+    void ArmStateController::stopping(const ros::Time& time)
+    {
+        for(size_t i=0; i<joint_handles_.size(); i++) 
+        {
+            joint_stiffness_handles_[i].setCommand(previous_stiffness_[i]);
+        }
+    }
+    
+}
+
+PLUGINLIB_EXPORT_CLASS(arm_state_controller::ArmStateController, controller_interface::ControllerBase)

--- a/lwr_controllers/src/arm_state_controller.cpp
+++ b/lwr_controllers/src/arm_state_controller.cpp
@@ -60,7 +60,7 @@ namespace arm_state_controller
                 for (unsigned i = 0; i < joint_handles_.size(); i++) {
                     (*joint_position_)(i) = joint_handles_[i].getPosition();
                     (*joint_velocity_)(i) = joint_handles_[i].getVelocity();
-                    (*joint_acceleration_)(i) = 0;  // TODO: compute from previous velocity?
+                    (*joint_acceleration_)(i) = 0; 
                 }
                                 
                 // Compute Dynamics 
@@ -96,6 +96,8 @@ namespace arm_state_controller
                 for (unsigned int i = 0; i < 6; i++) 
                     for (unsigned int j = 0; j < kdl_chain_.getNrOfJoints(); j++)
                         wrench[i] += jinv(i,j) * realtime_pub_->msg_.est_ext_torques[j];
+                    
+                tf::wrenchKDLToMsg(wrench, realtime_pub_->msg_.est_ee_wrench_base);        
                     
                 // Transform cartesian wrench into tool reference frame
                 KDL::Frame tool_frame;

--- a/lwr_controllers/src/arm_state_controller.cpp
+++ b/lwr_controllers/src/arm_state_controller.cpp
@@ -4,6 +4,7 @@
 #include <lwr_controllers/arm_state_controller.h>
 #include <kdl_conversions/kdl_msg.h>
 #include <utils/pseudo_inversion.h>
+#include <control_toolbox/filters.h>
 
 namespace arm_state_controller  
 {
@@ -58,9 +59,10 @@ namespace arm_state_controller
                 last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
                 
                 for (unsigned i = 0; i < joint_handles_.size(); i++) {
+                    float acceleration = filters::exponentialSmoothing((joint_handles_[i].getPosition() - (*joint_position_)(i))/period.toSec(), joint_handles_[i].getVelocity(), 0.2);
                     (*joint_position_)(i) = joint_handles_[i].getPosition();
                     (*joint_velocity_)(i) = joint_handles_[i].getVelocity();
-                    (*joint_acceleration_)(i) = 0; 
+                    (*joint_acceleration_)(i) = acceleration; 
                 }
                                 
                 // Compute Dynamics 

--- a/lwr_controllers/src/arm_state_controller.cpp
+++ b/lwr_controllers/src/arm_state_controller.cpp
@@ -59,7 +59,7 @@ namespace arm_state_controller
                 last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
                 
                 for (unsigned i = 0; i < joint_handles_.size(); i++) {
-                    float acceleration = filters::exponentialSmoothing((joint_handles_[i].getPosition() - (*joint_position_)(i))/period.toSec(), joint_handles_[i].getVelocity(), 0.2);
+                    float acceleration = filters::exponentialSmoothing((joint_handles_[i].getVelocity() - (*joint_velocity_)(i))/period.toSec(), (*joint_acceleration_)(i), 0.2);
                     (*joint_position_)(i) = joint_handles_[i].getPosition();
                     (*joint_velocity_)(i) = joint_handles_[i].getVelocity();
                     (*joint_acceleration_)(i) = acceleration; 

--- a/lwr_controllers/src/arm_state_controller.cpp
+++ b/lwr_controllers/src/arm_state_controller.cpp
@@ -3,6 +3,7 @@
 
 #include <lwr_controllers/arm_state_controller.h>
 #include <kdl_conversions/kdl_msg.h>
+#include <utils/pseudo_inversion.h>
 
 namespace arm_state_controller  
 {
@@ -87,11 +88,14 @@ namespace arm_state_controller
                     return;
                 }
                 
+                Eigen::MatrixXd jinv;
+                pseudo_inverse(jacobian_->data.transpose(),jinv,false);                
+                
                 KDL::Wrench wrench;
                 
                 for (unsigned int i = 0; i < 6; i++) 
                     for (unsigned int j = 0; j < kdl_chain_.getNrOfJoints(); j++)
-                        wrench[i] += (*jacobian_)(i,j) * realtime_pub_->msg_.est_ext_torques[j];
+                        wrench[i] += jinv(i,j) * realtime_pub_->msg_.est_ext_torques[j];
                     
                 // Transform cartesian wrench into tool reference frame
                 KDL::Frame tool_frame;

--- a/lwr_controllers/src/arm_state_controller.cpp
+++ b/lwr_controllers/src/arm_state_controller.cpp
@@ -91,7 +91,7 @@ namespace arm_state_controller
                 }
                 
                 Eigen::MatrixXd jinv;
-                pseudo_inverse(jacobian_->data.transpose(),jinv,false);                
+                pseudo_inverse(jacobian_->data.transpose(),jinv,true);                
                 
                 KDL::Wrench wrench;
                 

--- a/lwr_description/model/kuka_lwr.urdf.xacro
+++ b/lwr_description/model/kuka_lwr.urdf.xacro
@@ -12,7 +12,9 @@
 
 	<!-- properties /-->
 	<xacro:property name="base_mass" value="2.0"/>
-	<xacro:property name="link_mass" value="2.0"/>
+	<xacro:property name="link_mass" value="2.35"/>
+    <xacro:property name="wrist_mass" value="1.1"/>
+    <xacro:property name="tip_mass" value="0.25"/>
 	<xacro:property name="velocity_scale" value="1"/>
 	<xacro:property name="effort_scale" value="1"/>
 
@@ -344,9 +346,9 @@
 
 	<link name="${name}_6_link">
 		<inertial>
-			<mass value="0.2"/>
+			<mass value="${wrist_mass}"/>
 			<origin rpy="0 0 0" xyz="0 0 0.0625"/>
-			<cuboid_inertia_def length="0.125" width="0.125" height="0.125" mass="0.2"/>
+			<cuboid_inertia_def length="0.125" width="0.125" height="0.125" mass="${wrist_mass}"/>
 		</inertial>
 
 		<visual>
@@ -385,9 +387,9 @@
 
 	<link name="${name}_7_link">
 		<inertial>
-			<mass value="0.2"/>
+			<mass value="${tip_mass}"/>
 			<origin xyz="0 0 0"/>
-			<cuboid_inertia_def length="1" width="1" height="1" mass="0.2"/>
+			<cuboid_inertia_def length="0.1" width="0.1" height="0.1" mass="${tip_mass}"/>
 		</inertial>
 		<visual>
 			<origin xyz="0 0 0" rpy="0 0 ${M_PI}"/>

--- a/lwr_description/model/utils.xacro
+++ b/lwr_description/model/utils.xacro
@@ -5,17 +5,17 @@
 
   <!-- Little helper macro to define the inertia matrix needed for links. -->
   <xacro:macro name="cuboid_inertia_def" params="width height length mass">
-    <inertia ixx="${mass * (height * height + length * length) / 12)}"
-             iyy="${mass * (width * width + length * length) / 12)}"
-             izz="${mass * (width * width + height * height) / 12)}"
+    <inertia ixx="${mass * (height * height + length * length) / 12}"
+             iyy="${mass * (width * width + length * length) / 12}"
+             izz="${mass * (width * width + height * height) / 12}"
              ixy="0" iyz="0" ixz="0"/>
   </xacro:macro>
 
   <!-- length is along the y-axis! -->
   <xacro:macro name="cylinder_inertia_def" params="radius length mass">
-    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12)}"
-             iyy="${mass * radius* radius / 2)}"
-             izz="${mass * (3 * radius * radius + length * length) / 12)}"
+    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12}"
+             iyy="${mass * radius* radius / 2}"
+             izz="${mass * (3 * radius * radius + length * length) / 12}"
              ixy="0" iyz="0" ixz="0"/>
   </xacro:macro>
 

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -43,7 +43,7 @@ void LWRHW::reset()
     joint_velocity_command_[j] = 0.0;
     joint_effort_command_[j] = 0.0;
     joint_stiffness_command_[j] = 2500.0;
-    joint_damping_command_[j] = 0.0;
+    joint_damping_command_[j] = 0.7;
   }
 
   return;

--- a/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
+++ b/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
@@ -16,6 +16,7 @@
 
 	<!-- in case you want to load moveit from here, it might be hard with the real HW though -->
 	<arg name="load_moveit" default="false"/>
+    <arg name="load_moveit_rviz" default="false"/>
 
 	<!-- this must be in accordance to the hardware interface in the model, there should be a xacro parameter to facilitate that to users -->
 	<!-- arg name="controller" default="joint_position_trajectory_controller"/-->
@@ -69,7 +70,7 @@
         </include>
 
 		<!-- run Rviz and load the default config to see the state of the move_group node -->
-		<include file="$(find single_lwr_moveit)/launch/moveit_rviz.launch">
+		<include if="$(arg load_moveit_rviz)" file="$(find single_lwr_moveit)/launch/moveit_rviz.launch">
 			<arg name="config" value="true"/>
 			<arg name="debug" value="false"/>
 		</include>

--- a/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
+++ b/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
@@ -101,7 +101,7 @@
 		</group>
 
 		<!-- spawn only desired controllers in current namespace -->
-		<node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"  args="joint_state_controller $(arg controllers)"/>
+		<node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"  args="joint_state_controller ArmStateController $(arg controllers)"/>
 	</group>
 
 </launch>

--- a/single_lwr_example/single_lwr_robot/config/controllers.yaml
+++ b/single_lwr_example/single_lwr_robot/config/controllers.yaml
@@ -28,6 +28,12 @@ lwr:
       - lwr_6_joint_stiffness
 
 ## OTHER CUSTOM CONTROLLERS LEFT HERE AS EXAMPLES
+  ArmStateController: 
+    type: arm_state_controller/ArmStateController
+    root_name: lwr_base_link
+    tip_name: lwr_7_link
+    publish_rate: 30
+
   GravityCompensation: 
     type: lwr_controllers/GravityCompensation
     root_name: lwr_base_link


### PR DESCRIPTION
This pull request contains:

- an ArmStateController which publishes the estimated torque acting on the robot joints, based on the dynamic model contained in the URDF (to be extended as in issue #38)
- A refining of the links mass, in order to improve the external torque estimation

The current status is a precision in estimating external torques around +/-1.5Nm, with no tool attached to the robot. In other words, the maximum torque that is estimated for the robot with nothing attached in various positions is +/-1.5Nm. This should be a good starting point, since the internal torque estimation of the Kuka controller also has a comparable precision.