### PR TITLE
Implement low-level software stop using ROS topic for all interfaces

### DIFF
--- a/lwr_hw/launch/lwr_hw.launch
+++ b/lwr_hw/launch/lwr_hw.launch
@@ -5,6 +5,7 @@
 	<arg name="ip" default="192.168.0.20"/>
 	<arg name="use_default_joint_names" default="true"/>
 	<arg name="use_default_namespace" default="true"/>
+	<arg name="respawning" default="false"/>
 
 	<!-- LAUNCH IMPLEMENTATION -->
 
@@ -16,7 +17,7 @@
 		<param name="port" value="$(arg port)"/>
 		<param name="ip" value="$(arg ip)"/>
 		<!-- the real hardware interface /-->
-		<node name="lwr_hw" pkg="lwr_hw" type="lwr_hw_node" respawn="false" output="screen"/>
+		<node name="lwr_hw" pkg="lwr_hw" type="lwr_hw_node" respawn="$(arg respawning)" output="screen"/>
 	</group>
 	<group unless="$(arg use_default_joint_names)">
 		<group if="$(arg use_default_joint_names)">
@@ -26,7 +27,7 @@
 		<param name="port" value="$(arg port)"/>
 		<param name="ip" value="$(arg ip)"/>
 		<!-- the real hardware interface /-->
-		<node name="lwr_hw" pkg="lwr_hw" type="lwr_hw_node" respawn="false" output="screen"/>
+		<node name="lwr_hw" pkg="lwr_hw" type="lwr_hw_node" respawn="$(arg respawning)" output="screen"/>
 	</group>
 
 </launch>


### PR DESCRIPTION
It's simple, and it works. Probably it does not comply with ROS interfaces and so on, but an emergency stop should not care about whether moveit, ros-actionlib, ros-control and so on are running or not. It should just stop the robot from moving.
Bonus: you can resume it by sending start on the same topic!