### PR TITLE
fixed syntax error in xacro expression

### DIFF
--- a/lwr_description/model/utils.xacro
+++ b/lwr_description/model/utils.xacro
@@ -5,17 +5,17 @@
 
   <!-- Little helper macro to define the inertia matrix needed for links. -->
   <xacro:macro name="cuboid_inertia_def" params="width height length mass">
-    <inertia ixx="${mass * (height * height + length * length) / 12)}"
-             iyy="${mass * (width * width + length * length) / 12)}"
-             izz="${mass * (width * width + height * height) / 12)}"
+    <inertia ixx="${mass * (height * height + length * length) / 12}"
+             iyy="${mass * (width * width + length * length) / 12}"
+             izz="${mass * (width * width + height * height) / 12}"
              ixy="0" iyz="0" ixz="0"/>
   </xacro:macro>
 
   <!-- length is along the y-axis! -->
   <xacro:macro name="cylinder_inertia_def" params="radius length mass">
-    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12)}"
-             iyy="${mass * radius* radius / 2)}"
-             izz="${mass * (3 * radius * radius + length * length) / 12)}"
+    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12}"
+             iyy="${mass * radius* radius / 2}"
+             izz="${mass * (3 * radius * radius + length * length) / 12}"
              ixy="0" iyz="0" ixz="0"/>
   </xacro:macro>
 


### PR DESCRIPTION
This commit fixes #47 the syntax error (in utils.xacro):
`unexpected EOF while parsing (<string>, line 1) when evaluating expression 'mass * (3 * radius * radius + length * length) / 12)'`