### PR TITLE
Getting the cartesian impedance controller to run

### DIFF
--- a/lwr_controllers/src/cartesian_impedance_controller.cpp
+++ b/lwr_controllers/src/cartesian_impedance_controller.cpp
@@ -174,11 +174,11 @@ namespace lwr_controllers
             if(c < 12)
                 cart_handles_.at(c).setCommand(cur_T_FRI.at(c));
             if(c > 11 && c < 18)
-                cart_handles_.at(c-12).setCommand(k_des_[c-12]);
+                cart_handles_.at(c).setCommand(k_des_[c-12]);
             if(c > 17 && c < 24)
-                cart_handles_.at(c-18).setCommand(d_des_[c-18]);
+                cart_handles_.at(c).setCommand(d_des_[c-18]);
             if(c > 23 && c < 30)
-                cart_handles_.at(c-24).setCommand(f_des_[c-24]);
+                cart_handles_.at(c).setCommand(f_des_[c-24]);
         }
     }
 

--- a/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
@@ -212,7 +212,7 @@ public:
 
     if(desired_strategy == getControlStrategy())
     {
-      std::cout << "The ControlStrategy didn't changed, it is already: " << getControlStrategy() << std::endl;
+      std::cout << "The ControlStrategy didn't change, it is already: " << getControlStrategy() << std::endl;
     }
     else
     {

--- a/lwr_hw/src/fri/friremote.cpp
+++ b/lwr_hw/src/fri/friremote.cpp
@@ -220,7 +220,7 @@ int friRemote::doCartesianImpedanceControl(const float newCartPosition[FRI_CART_
 {
 
 		// Helper, if not properly initialized or the like...
-	cmd.cmd.cmdFlags=0;
+// 	cmd.cmd.cmdFlags=0;
 	if ( newCartPosition )
 	{
 		cmd.cmd.cmdFlags|=FRI_CMD_CARTPOS;

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -553,7 +553,7 @@ namespace lwr_hw
 
     if(desired_strategy == getControlStrategy())
     {
-      std::cout << "The ControlStrategy didn't changed, it is already: " << getControlStrategy() << std::endl;
+      std::cout << "The ControlStrategy didn't change, it is already: " << getControlStrategy() << std::endl;
     }
     else
     {

--- a/single_lwr_example/single_lwr_robot/config/controllers.yaml
+++ b/single_lwr_example/single_lwr_robot/config/controllers.yaml
@@ -32,7 +32,13 @@ lwr:
     type: lwr_controllers/GravityCompensation
     root_name: lwr_base_link
     tip_name: lwr_7_link
-
+    
+  cartesian_impedance_controller:
+    type: lwr_controllers/CartesianImpedanceController
+    robot_name: lwr
+    root_name: lwr_base_link
+    tip_name: lwr_7_link
+    
   #   Joint Impedance Controllers
   joint_impedance_controller:
     type: lwr_controllers/JointImpedanceController

--- a/single_lwr_example/single_lwr_robot/config/controllers.yaml
+++ b/single_lwr_example/single_lwr_robot/config/controllers.yaml
@@ -1,5 +1,5 @@
 lwr:
-  # CONTROLLERS USED IN THE EXAMLE
+  # CONTROLLERS USED IN THE EXAMPLE
   joint_state_controller:
     type: joint_state_controller/JointStateController
     publish_rate: 100  


### PR DESCRIPTION
Hey Carlos,

sorry for the long silence. I am using the 4+ again and I am trying out the vito-devel branch, since it makes it possible to use the native impedance controller.

However I found a couple of issues. Now I can start the controller while using single_lwr.launch and it looks like the controller sends meaningful values over to FRI. 
