### PR TITLE
Updating some deprecated commands for ROS Kinetic

### DIFF
--- a/lwr_controllers/src/computed_torque_controller.cpp
+++ b/lwr_controllers/src/computed_torque_controller.cpp
@@ -107,7 +107,7 @@ namespace lwr_controllers
             pid_cmd_(i) = joint_des_states_.qdotdot(i) + Kv_(i)*(joint_des_states_.qdot(i) - joint_msr_states_.qdot(i)) + Kp_(i)*(joint_des_states_.q(i) - joint_msr_states_.q(i));
             cg_cmd_(i) = C_(i)*joint_msr_states_.qdot(i) + G_(i);
         }
-        KDL::Multiply(M_,pid_cmd_,tau_cmd_);
+        tau_cmd_.data = M_.data * pid_cmd_.data;
         KDL::Add(tau_cmd_,cg_cmd_,tau_cmd_);
         
         for(size_t i=0; i<joint_handles_.size(); i++)

--- a/lwr_description/model/kuka_lwr.gazebo.xacro
+++ b/lwr_description/model/kuka_lwr.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 	<xacro:macro name="kuka_lwr_gazebo" params="name">
 

--- a/lwr_description/model/kuka_lwr.transmission.xacro
+++ b/lwr_description/model/kuka_lwr.transmission.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 	<xacro:property name="Interface10" value="PositionJointInterface"/>
 	<xacro:property name="Interface30" value="EffortJointInterface"/>

--- a/lwr_description/model/kuka_lwr.urdf.xacro
+++ b/lwr_description/model/kuka_lwr.urdf.xacro
@@ -27,7 +27,7 @@
 
 		<!-- First (shoulder) element of the arm. Fixed to its parent. -->
 		<joint name="${parent}_${name}_base_joint" type="fixed">
-			<insert_block name="origin"/>
+			<xacro:insert_block name="origin"/>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
 			<parent link="${parent}"/>
 			<child link="${name}_base_link"/>

--- a/lwr_description/model/kuka_materials.xacro
+++ b/lwr_description/model/kuka_materials.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <material name="Kuka/DarkGrey">
     <color rgba="0.3 0.3 0.3 1.0"/>
   </material>

--- a/lwr_hw/CMakeLists.txt
+++ b/lwr_hw/CMakeLists.txt
@@ -40,7 +40,6 @@ catkin_package(
     std_msgs
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME} lwr_hw_gazebo_plugin friremote
-  DEPENDS gazebo
 )
 
 ###########

--- a/lwr_hw/include/lwr_hw/lwr_hw.h
+++ b/lwr_hw/include/lwr_hw/lwr_hw.h
@@ -56,6 +56,17 @@ public:
   enum ControlStrategy {JOINT_POSITION = 10, CARTESIAN_IMPEDANCE = 20, JOINT_IMPEDANCE = 30, JOINT_EFFORT = 40, JOINT_STIFFNESS = 50, GRAVITY_COMPENSATION = 90};
   virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) const;
   virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list);
+  
+  /**
+   * @brief Function to get the control strategy based on the list of controllers to be started/stopped
+   * 
+   * @param start_list controllers to be started
+   * @param stop_list controllers to be stopped
+   * @param default_control_strategy value to use as a default return value
+   * 
+   * @return the output control strategy found based on the lists
+   */
+  static ControlStrategy getNewControlStrategy(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list, ControlStrategy default_control_strategy = JOINT_POSITION);
 
   // This functions must be implemented depending on the outlet (Real FRI/FRIL, Gazebo, etc.)
   virtual bool init() = 0;

--- a/lwr_hw/include/lwr_hw/lwr_hw.h
+++ b/lwr_hw/include/lwr_hw/lwr_hw.h
@@ -54,7 +54,11 @@ public:
 // GRAVITY_COMPENSATION -> (does not exist in the real robot, achieved with low stiffness)
   // __Note__: StiffnessJointInterface + EffortJointInterface = ImpedanceJointInterface
   enum ControlStrategy {JOINT_POSITION = 10, CARTESIAN_IMPEDANCE = 20, JOINT_IMPEDANCE = 30, JOINT_EFFORT = 40, JOINT_STIFFNESS = 50, GRAVITY_COMPENSATION = 90};
+#if ROS_VERSION_MINIMUM(1,12,6)
+  virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) const;
+#else
   virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) const;
+#endif
   virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list);
   
   /**

--- a/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
@@ -170,28 +170,7 @@ public:
     // at this point, we now that there is only one controller that ones to command joints
     ControlStrategy desired_strategy = JOINT_POSITION; // default
 
-    // If any of the controllers in the start list works on a velocity interface, the switch can't be done.
-    for ( std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it )
-    {
-      if( it->hardware_interface.compare( std::string("hardware_interface::PositionJointInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::PositionJointInterface (JOINT_POSITION)" << std::endl;
-        desired_strategy = JOINT_POSITION;
-        break;
-      }
-      else if( it->hardware_interface.compare( std::string("hardware_interface::EffortJointInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::EffortJointInterface (JOINT_IMPEDANCE)" << std::endl;
-        desired_strategy = JOINT_IMPEDANCE;
-        break;
-      }
-      else if( it->hardware_interface.compare( std::string("hardware_interface::PositionCartesianInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::PositionCartesianInterface (CARTESIAN_IMPEDANCE)" << std::endl;
-        desired_strategy = CARTESIAN_IMPEDANCE;
-        break;
-      }
-    }
+    desired_strategy = getNewControlStrategy(start_list,stop_list,desired_strategy);
 
     for (int j = 0; j < n_joints_; ++j)
     {

--- a/lwr_hw/include/lwr_hw/lwr_hw_fril.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fril.hpp
@@ -150,22 +150,11 @@ public:
     // at this point, we now that there is only one controller that ones to command joints
     ControlStrategy desired_strategy = JOINT_POSITION; // default
 
-    // If any of the controllers in the start list works on a velocity interface, the switch can't be done.
-    for ( std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it )
-    {
-      if( it->hardware_interface.compare( std::string("hardware_interface::PositionJointInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::PositionJointInterface (JOINT_POSITION)" << std::endl;
+    desired_strategy = getNewControlStrategy(start_list,stop_list,desired_strategy);
+    
+    // only allow joint position and joint impedance control strategies, otherwise set the default (JOINT_POSITION) strategy
+    if(desired_strategy != JOINT_POSITION && desired_strategy != JOINT_IMPEDANCE)
         desired_strategy = JOINT_POSITION;
-        break;
-      }
-      else if( it->hardware_interface.compare( std::string("hardware_interface::EffortJointInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::EffortJointInterface (JOINT_IMPEDANCE)" << std::endl;
-        desired_strategy = JOINT_IMPEDANCE;
-        break;
-      }
-    }
 
     for (int j = 0; j < n_joints_; ++j)
     {

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -512,28 +512,7 @@ namespace lwr_hw
     // at this point, we now that there is only one controller that ones to command joints
     ControlStrategy desired_strategy = JOINT_POSITION; // default
 
-    // If any of the controllers in the start list works on a velocity interface, the switch can't be done.
-    for ( std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it )
-    {
-      if( it->hardware_interface.compare( std::string("hardware_interface::PositionJointInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::PositionJointInterface (JOINT_POSITION)" << std::endl;
-        desired_strategy = JOINT_POSITION;
-        break;
-      }
-      else if( it->hardware_interface.compare( std::string("hardware_interface::EffortJointInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::EffortJointInterface (JOINT_IMPEDANCE)" << std::endl;
-        desired_strategy = JOINT_IMPEDANCE;
-        break;
-      }
-      else if( it->hardware_interface.compare( std::string("hardware_interface::PositionCartesianInterface") ) == 0 )
-      {
-        std::cout << "Request to switch to hardware_interface::PositionCartesianInterface (CARTESIAN_IMPEDANCE)" << std::endl;
-        desired_strategy = CARTESIAN_IMPEDANCE;
-        break;
-      }
-    }
+    desired_strategy = getNewControlStrategy(start_list,stop_list,desired_strategy);
 
     for (int j = 0; j < n_joints_; ++j)
     {
@@ -563,6 +542,34 @@ namespace lwr_hw
     }
   }
 
-  
+  LWRHW::ControlStrategy LWRHW::getNewControlStrategy(const std::list< hardware_interface::ControllerInfo >& start_list, const std::list< hardware_interface::ControllerInfo >& stop_list, lwr_hw::LWRHW::ControlStrategy default_control_strategy)
+  {
+    ControlStrategy desired_strategy = default_control_strategy;
+    
+    // If any of the controllers in the start list works on a velocity interface, the switch can't be done.
+    for ( std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it )
+    {
+        if( it->hardware_interface.compare( std::string("hardware_interface::PositionJointInterface") ) == 0 )
+        {
+            std::cout << "Request to switch to hardware_interface::PositionJointInterface (JOINT_POSITION)" << std::endl;
+            desired_strategy = JOINT_POSITION;
+            break;
+        }
+        else if( it->hardware_interface.compare( std::string("hardware_interface::EffortJointInterface") ) == 0 )
+        {
+            std::cout << "Request to switch to hardware_interface::EffortJointInterface (JOINT_IMPEDANCE)" << std::endl;
+            desired_strategy = JOINT_IMPEDANCE;
+            break;
+        }
+        else if( it->hardware_interface.compare( std::string("hardware_interface::PositionCartesianInterface") ) == 0 )
+        {
+            std::cout << "Request to switch to hardware_interface::PositionCartesianInterface (CARTESIAN_IMPEDANCE)" << std::endl;
+            desired_strategy = CARTESIAN_IMPEDANCE;
+            break;
+        }
+    }
+    
+    return desired_strategy;
+  }
   
 }

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -457,7 +457,7 @@ namespace lwr_hw
 
   bool LWRHW::canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) const
   {
-    int counter = 0;
+    int counter_position = 0, counter_effort = 0, counter_cartesian = 0;
     
     for ( std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it )
     {
@@ -473,19 +473,19 @@ namespace lwr_hw
       {
         // Debug
         // std::cout << "One controller wants to work on hardware_interface::PositionJointInterface" << std::endl;
-        ++counter;
+        counter_position = 1;
       }
       else if( it->hardware_interface.compare( std::string("hardware_interface::EffortJointInterface") ) == 0 )
       {
         // Debug
         // std::cout << "One controller wants to work on hardware_interface::EffortJointInterface" << std::endl;
-        ++counter;
+        counter_effort = 1;
       }
       else if( it->hardware_interface.compare( std::string("hardware_interface::PositionCartesianInterface") ) == 0 )
       {
         // Debug
         // std::cout << "One controller wants to work on hardware_interface::PositionCartesianInterface" << std::endl;
-        ++counter;
+        counter_cartesian = 1;
       }
       else
       {
@@ -494,7 +494,7 @@ namespace lwr_hw
       }
     }
 
-    if( counter > 1 )
+    if( (counter_position+counter_effort+counter_cartesian)>1)
     {
       std::cout << "OOPS! Currently we are using the JointCommandInterface to switch mode, this is not strictly correct. " 
                 << "This is temporary until a joint_mode_controller is available (so you can have different interfaces available in different modes)"

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -455,6 +455,50 @@ namespace lwr_hw
     return true;
   }
 
+#if ROS_VERSION_MINIMUM(1,12,6)
+    bool LWRHW::prepareSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) const
+    {
+        int counter_position = 0, counter_effort = 0, counter_cartesian = 0;
+        
+        for ( std::list<hardware_interface::ControllerInfo>::const_iterator ci_it = start_list.begin(); ci_it != start_list.end(); ++ci_it )
+        {
+            for( std::vector<hardware_interface::InterfaceResources>::const_iterator it = ci_it->claimed_resources.begin(); it != ci_it->claimed_resources.end(); ++it)
+            {
+                // If any of the controllers in the start list works on a velocity interface, the switch can't be done.
+                if( it->hardware_interface.compare( std::string("hardware_interface::VelocityJointInterface") ) == 0 )
+                {
+                    std::cout << "The given controllers to start work on a velocity joint interface, and this robot does not have such an interface. "
+                    << "The switch can't be done" << std::endl;
+                    return false;
+                }
+                if( it->hardware_interface.compare( std::string("hardware_interface::PositionJointInterface") ) == 0 )
+                {
+                    counter_position = 1;
+                }
+                else if( it->hardware_interface.compare( std::string("hardware_interface::EffortJointInterface") ) == 0 )
+                {
+                    counter_effort = 1;
+                }
+                else if( it->hardware_interface.compare( std::string("hardware_interface::PositionCartesianInterface") ) == 0 )
+                {
+                    counter_cartesian = 1;
+                }
+            }
+        }
+        
+        if( (counter_position+counter_effort+counter_cartesian)>1)
+        {
+            std::cout << "OOPS! Currently we are using the JointCommandInterface to switch mode, this is not strictly correct. " 
+            << "This is temporary until a joint_mode_controller is available (so you can have different interfaces available in different modes)"
+            << "Having said this, we do not support more than one controller that ones to act on any given JointCommandInterface"
+            << "and we can't switch"
+            << std::endl;
+            return false;
+        }
+        
+        return true;
+    }
+#else
   bool LWRHW::canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) const
   {
     int counter_position = 0, counter_effort = 0, counter_cartesian = 0;
@@ -506,6 +550,7 @@ namespace lwr_hw
 
     return true;
   }
+#endif
 
   void LWRHW::doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list)
   {
@@ -542,6 +587,48 @@ namespace lwr_hw
     }
   }
 
+#if ROS_VERSION_MINIMUM(1,12,6)
+    LWRHW::ControlStrategy LWRHW::getNewControlStrategy(const std::list< hardware_interface::ControllerInfo >& start_list, const std::list< hardware_interface::ControllerInfo >& stop_list, LWRHW::ControlStrategy default_control_strategy)
+    {
+        ControlStrategy desired_strategy = default_control_strategy;
+        // NOTE that this allows to switch only based on the strategy of the first controller, but ROS kinetic would allow multiple interfaces and more
+        bool strategy_found = false;
+        
+        for ( std::list<hardware_interface::ControllerInfo>::const_iterator ci_it = start_list.begin(); ci_it != start_list.end(); ++ci_it )
+        {
+            for( std::vector<hardware_interface::InterfaceResources>::const_iterator it = ci_it->claimed_resources.begin(); it != ci_it->claimed_resources.end(); ++it)
+            {
+                if( it->hardware_interface.compare( std::string("hardware_interface::PositionJointInterface") ) == 0 )
+                {
+                    std::cout << "Request to switch to hardware_interface::PositionJointInterface (JOINT_POSITION)" << std::endl;
+                    desired_strategy = JOINT_POSITION;
+                    strategy_found = true;
+                    break;
+                }
+                else if( it->hardware_interface.compare( std::string("hardware_interface::EffortJointInterface") ) == 0 )
+                {
+                    std::cout << "Request to switch to hardware_interface::EffortJointInterface (JOINT_IMPEDANCE)" << std::endl;
+                    desired_strategy = JOINT_IMPEDANCE;
+                    strategy_found = true;
+                    break;
+                }
+                else if( it->hardware_interface.compare( std::string("hardware_interface::PositionCartesianInterface") ) == 0 )
+                {
+                    std::cout << "Request to switch to hardware_interface::PositionCartesianInterface (CARTESIAN_IMPEDANCE)" << std::endl;
+                    desired_strategy = CARTESIAN_IMPEDANCE;
+                    strategy_found = true;
+                    break;
+                }
+            }
+            if(strategy_found)
+            {
+                break;
+            }
+        }
+        
+        return desired_strategy;
+    }
+#else
   LWRHW::ControlStrategy LWRHW::getNewControlStrategy(const std::list< hardware_interface::ControllerInfo >& start_list, const std::list< hardware_interface::ControllerInfo >& stop_list, lwr_hw::LWRHW::ControlStrategy default_control_strategy)
   {
     ControlStrategy desired_strategy = default_control_strategy;
@@ -571,5 +658,6 @@ namespace lwr_hw
     
     return desired_strategy;
   }
+#endif
   
 }

--- a/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
+++ b/single_lwr_example/single_lwr_launch/launch/single_lwr.launch
@@ -27,7 +27,7 @@
 	<!-- LAUNCH IMPLEMENTATION -->
 
 	<!-- the urdf/sdf parameter -->
-	<param name="robot_description" command="$(find xacro)/xacro.py $(find single_lwr_robot)/robot/$(arg robot_name).urdf.xacro"/>
+	<param name="robot_description" command="$(find xacro)/xacro --inorder $(find single_lwr_robot)/robot/$(arg robot_name).urdf.xacro"/>
 	
 	<!-- joint and robot state publishers of the full robot description -->
 	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
@@ -87,7 +87,7 @@
 	<group ns="lwr">
 		<group if="$(arg lwr_powered)">
 			<!--add a copy of the robot description within the name space -->
-			<param name="robot_description" command="$(find xacro)/xacro.py $(find single_lwr_robot)/robot/$(arg robot_name).urdf.xacro"/>
+			<param name="robot_description" command="$(find xacro)/xacro --inorder $(find single_lwr_robot)/robot/$(arg robot_name).urdf.xacro"/>
 
 			<include file="$(find lwr_hw)/launch/lwr_hw.launch">
 				<arg name="port" value="$(arg port)"/>

--- a/single_lwr_example/single_lwr_moveit/launch/planning_context.launch
+++ b/single_lwr_example/single_lwr_moveit/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find single_lwr_robot)/robot/single_lwr_robot.urdf.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find single_lwr_robot)/robot/single_lwr_robot.urdf.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find single_lwr_moveit)/config/single_lwr_robot.srdf" />


### PR DESCRIPTION
Few changes to avoid various warnings when loading the model in ROS Kinetic.
All changes are compatible with ROS Indigo.