### PR TITLE
Improving joint impedance controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ ros/kuka_lwr/lwr_moveit/default_warehouse_mongo_db/journal/prealloc.*
 
 # Kdev and QTcreator files
 *.kdev_include_paths
+*.kdev4
 *.user
 
 # Typical build folders

--- a/lwr_controllers/CMakeLists.txt
+++ b/lwr_controllers/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(${PROJECT_NAME}
   src/gravity_compensation.cpp
   src/arm_state_controller.cpp
   src/cartesian_impedance_controller.cpp
+  src/KinematicChainControllerBase.cpp
 )
 
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp)

--- a/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
+++ b/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
@@ -47,6 +47,12 @@ namespace controller_interface
 		} joint_limits_;
 
 		std::vector<typename JI::ResourceHandleType> joint_handles_;
+        std::vector<typename JI::ResourceHandleType> joint_stiffness_handles_;
+        std::vector<typename JI::ResourceHandleType> joint_damping_handles_;
+        std::vector<typename JI::ResourceHandleType> joint_set_point_handles_;
+        
+        bool getHandles(JI *robot);
+        
 	};
     
     template <typename JI>
@@ -161,12 +167,8 @@ namespace controller_interface
         }
 
         // Get joint handles for all of the joints in the chain
-        for(std::vector<KDL::Segment>::const_iterator it = kdl_chain_.segments.begin(); it != kdl_chain_.segments.end(); ++it)
-        {
-            joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
-            ROS_DEBUG("%s", it->getJoint().getName().c_str() );
-        }
-
+        getHandles(robot);
+        
         ROS_DEBUG("Number of joints in handle = %lu", joint_handles_.size() );
         
         joint_msr_states_.resize(kdl_chain_.getNrOfJoints());
@@ -174,7 +176,19 @@ namespace controller_interface
 
         return true;
     }
-
+    
+    template <typename JI>
+    bool KinematicChainControllerBase<JI>::getHandles(JI *robot)
+    {
+        for(std::vector<KDL::Segment>::const_iterator it = kdl_chain_.segments.begin(); it != kdl_chain_.segments.end(); ++it)
+        {
+            joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
+            ROS_DEBUG("%s", it->getJoint().getName().c_str() );
+        }        
+        return true;
+    }
+    
+    
 }
 
 #endif

--- a/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
+++ b/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
@@ -182,8 +182,11 @@ namespace controller_interface
     {
         for(std::vector<KDL::Segment>::const_iterator it = kdl_chain_.segments.begin(); it != kdl_chain_.segments.end(); ++it)
         {
-            joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
-            ROS_DEBUG("%s", it->getJoint().getName().c_str() );
+            if ( it->getJoint().getType() != 8 )
+            {
+                joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
+                ROS_DEBUG("%s", it->getJoint().getName().c_str() );
+            }
         }        
         return true;
     }

--- a/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
+++ b/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
@@ -182,7 +182,7 @@ namespace controller_interface
     {
         for(std::vector<KDL::Segment>::const_iterator it = kdl_chain_.segments.begin(); it != kdl_chain_.segments.end(); ++it)
         {
-            if ( it->getJoint().getType() != 8 )
+            if ( it->getJoint().getType() != KDL::Joint::None )
             {
                 joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
                 ROS_DEBUG("%s", it->getJoint().getName().c_str() );

--- a/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
+++ b/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
@@ -30,7 +30,7 @@ namespace lwr_controllers
 
 		void update(const ros::Time& time, const ros::Duration& period);
 		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
-		void setParam(const std_msgs::Float64MultiArray::ConstPtr &msg, KDL::JntArray& array, std::string s);
+		void setParam(const std_msgs::Float64MultiArray::ConstPtr &msg, KDL::JntArray* array, std::string s);
         
 	private:
 

--- a/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
+++ b/lwr_controllers/include/lwr_controllers/joint_impedance_controller.h
@@ -30,19 +30,16 @@ namespace lwr_controllers
 
 		void update(const ros::Time& time, const ros::Duration& period);
 		void command(const std_msgs::Float64MultiArray::ConstPtr &msg);
-		void setGains(const std_msgs::Float64MultiArray::ConstPtr &msg);
-
+		void setParam(const std_msgs::Float64MultiArray::ConstPtr &msg, KDL::JntArray& array, std::string s);
+        
 	private:
 
-		ros::Subscriber sub_gains_;
+		ros::Subscriber sub_stiffness_, sub_damping_, sub_add_torque_;
 		ros::Subscriber sub_posture_;
 
-		KDL::JntArrayVel dotq_msr_;
-		KDL::JntArray q_msr_, q_des_;
-		KDL::JntArray tau_des_, tau_cmd_, tau_gravity_;
+		KDL::JntArray q_des_;
+		KDL::JntArray tau_des_;
 		KDL::JntArray K_, D_;
-
-		boost::scoped_ptr<KDL::ChainDynParam> id_solver_gravity_;
 
 	};
 

--- a/lwr_controllers/src/KinematicChainControllerBase.cpp
+++ b/lwr_controllers/src/KinematicChainControllerBase.cpp
@@ -7,7 +7,7 @@ bool KinematicChainControllerBase<hardware_interface::EffortJointInterface>::get
 {
     for(std::vector<KDL::Segment>::const_iterator it = kdl_chain_.segments.begin(); it != kdl_chain_.segments.end(); ++it)
     {
-    	if ( it->getJoint().getType() != 8 )
+    	if ( it->getJoint().getType() != KDL::Joint::None )
         {
 	        joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
 	        joint_stiffness_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_stiffness")));

--- a/lwr_controllers/src/KinematicChainControllerBase.cpp
+++ b/lwr_controllers/src/KinematicChainControllerBase.cpp
@@ -7,11 +7,14 @@ bool KinematicChainControllerBase<hardware_interface::EffortJointInterface>::get
 {
     for(std::vector<KDL::Segment>::const_iterator it = kdl_chain_.segments.begin(); it != kdl_chain_.segments.end(); ++it)
     {
-        joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
-        joint_stiffness_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_stiffness")));
-        joint_damping_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_damping")));
-        joint_set_point_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_set_point")));
-        ROS_DEBUG("%s", it->getJoint().getName().c_str() );
+    	if ( it->getJoint().getType() != 8 )
+        {
+	        joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
+	        joint_stiffness_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_stiffness")));
+	        joint_damping_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_damping")));
+	        joint_set_point_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_set_point")));
+	        ROS_DEBUG("%s", it->getJoint().getName().c_str() );
+	    }
     }
     return true;
 }

--- a/lwr_controllers/src/KinematicChainControllerBase.cpp
+++ b/lwr_controllers/src/KinematicChainControllerBase.cpp
@@ -1,0 +1,19 @@
+
+#include <lwr_controllers/KinematicChainControllerBase.h>
+namespace controller_interface
+{
+template<>
+bool KinematicChainControllerBase<hardware_interface::EffortJointInterface>::getHandles(hardware_interface::EffortJointInterface *robot)
+{
+    for(std::vector<KDL::Segment>::const_iterator it = kdl_chain_.segments.begin(); it != kdl_chain_.segments.end(); ++it)
+    {
+        joint_handles_.push_back(robot->getHandle(it->getJoint().getName()));
+        joint_stiffness_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_stiffness")));
+        joint_damping_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_damping")));
+        joint_set_point_handles_.push_back(robot->getHandle(it->getJoint().getName() + std::string("_set_point")));
+        ROS_DEBUG("%s", it->getJoint().getName().c_str() );
+    }
+    return true;
+}
+}
+

--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -9,130 +9,108 @@
 #include <lwr_controllers/joint_impedance_controller.h>
 
 namespace lwr_controllers {
-
+    
 JointImpedanceController::JointImpedanceController() {}
 
 JointImpedanceController::~JointImpedanceController() {}
 
 bool JointImpedanceController::init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n)
 {
-  KinematicChainControllerBase<hardware_interface::EffortJointInterface>::init(robot, n);
-
-  K_.resize(kdl_chain_.getNrOfJoints());
-  D_.resize(kdl_chain_.getNrOfJoints());
-
-  ROS_DEBUG(" Number of joints in handle = %lu", joint_handles_.size() );
-
-  for (int i = 0; i < joint_handles_.size(); ++i){
-    if ( !nh_.getParam("stiffness_gains", K_(i) ) ){
-      ROS_WARN("Stiffness gain not set in yaml file, Using %f", K_(i));
-      }
+    KinematicChainControllerBase<hardware_interface::EffortJointInterface>::init(robot, n);
+    K_.resize(kdl_chain_.getNrOfJoints());
+    D_.resize(kdl_chain_.getNrOfJoints());
+    
+    ROS_DEBUG(" Number of joints in handle = %lu", joint_handles_.size() );
+    
+    for (int i = 0; i < joint_handles_.size(); ++i){
+        if ( !nh_.getParam("stiffness_gains", K_(i) ) ){
+            ROS_WARN("Stiffness gain not set in yaml file, Using %f", K_(i));
+        }
     }
-  for (int i = 0; i < joint_handles_.size(); ++i){
-    if ( !nh_.getParam("damping_gains", D_(i)) ){
-      ROS_WARN("Damping gain not set in yaml file, Using %f", D_(i));
-      }
+    for (int i = 0; i < joint_handles_.size(); ++i){
+        if ( !nh_.getParam("damping_gains", D_(i)) ){
+            ROS_WARN("Damping gain not set in yaml file, Using %f", D_(i));
+        }
     }
-
-
-
-  id_solver_gravity_.reset( new KDL::ChainDynParam( kdl_chain_, gravity_) );
-
-  dotq_msr_.resize(kdl_chain_.getNrOfJoints());
-  q_msr_.resize(kdl_chain_.getNrOfJoints());
-  q_des_.resize(kdl_chain_.getNrOfJoints());
-  tau_des_.resize(kdl_chain_.getNrOfJoints());
-  tau_cmd_.resize(kdl_chain_.getNrOfJoints());
-  tau_gravity_.resize(kdl_chain_.getNrOfJoints());
-  // K_.resize(kdl_chain_.getNrOfJoints());
-  // D_.resize(kdl_chain_.getNrOfJoints());
-
-  sub_gains_ = nh_.subscribe("gains", 1, &JointImpedanceController::setGains, this);
-  sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::command, this);
-
-
-  return true;
-
-
+    
+    q_des_.resize(kdl_chain_.getNrOfJoints());
+    tau_des_.resize(kdl_chain_.getNrOfJoints());
+    typedef  const std_msgs::Float64MultiArray::ConstPtr& msg_type;
+    sub_stiffness_ = nh_.subscribe<JointImpedanceController, msg_type>("stiffness", 1, boost::bind(&JointImpedanceController::setParam, this, _1, K_, "K"));
+    sub_damping_ = nh_.subscribe<JointImpedanceController, msg_type>("damping", 1, boost::bind(&JointImpedanceController::setParam, this, _1, D_, "D"));
+    sub_add_torque_ = nh_.subscribe<JointImpedanceController, msg_type>("additional_torque", 1, boost::bind(&JointImpedanceController::setParam, this, _1, tau_des_, "AddTorque"));
+    sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::command, this);
+    
+    return true;
+    
+    
 }
 
 void JointImpedanceController::starting(const ros::Time& time)
 {
-  // get joint positions
-  for(size_t i=0; i<joint_handles_.size(); i++) {
-    K_(i) = 300.0;
-    D_(i) = 0.7;
-    tau_des_(i) = 0.0;
-    dotq_msr_.q(i) = joint_handles_[i].getPosition();
-    q_des_(i) = dotq_msr_.q(i);
-    dotq_msr_.qdot(i) = joint_handles_[i].getVelocity();
+    // Initializing stiffness, damping, ext_torque and set point values
+    for(size_t i=0; i<joint_handles_.size(); i++) {
+        K_(i) = 300.0;
+        D_(i) = 0.7;
+        tau_des_(i) = 0.0;
+        q_des_(i) =joint_handles_[i].getPosition();
     }
-
-
+    
+    
 }
 
 void JointImpedanceController::update(const ros::Time& time, const ros::Duration& period)
 {
-
-  // get joint positions	
-  for(size_t i=0; i<joint_handles_.size(); i++) {
-    dotq_msr_.q(i) = joint_handles_[i].getPosition();
-    q_msr_(i) = dotq_msr_.q(i);
-    dotq_msr_.qdot(i) = joint_handles_[i].getVelocity();
-    }
-
-  //Compute control law
-  id_solver_gravity_->JntToGravity( q_msr_ , tau_gravity_ );
-  for(size_t i=0; i<joint_handles_.size(); i++) {
-    tau_cmd_(i) = K_(i) * (q_des_(i) - q_msr_(i)) + D_(i)*dotq_msr_.qdot(i) + tau_des_(i) + tau_gravity_(i);
-    joint_handles_[i].setCommand(tau_cmd_	(i));
-    }	
-
+    
+    //Compute control law. This controller sets all variables for the JointImpedance Interface from kuka
+    for(size_t i=0; i<joint_handles_.size(); i++) 
+    {
+        joint_handles_[i].setCommand(tau_des_(i));
+        joint_stiffness_handles_[i].setCommand(K_(i));
+        joint_damping_handles_[i].setCommand(D_(i));
+        joint_set_point_handles_[i].setCommand(q_des_(i));
+    }   
+    
 }
 
 
 void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstPtr &msg){
-  if (msg->data.size() == 0) {
-    ROS_INFO("Desired configuration must be: %lu dimension", joint_handles_.size());
+    if (msg->data.size() == 0) {
+        ROS_INFO("Desired configuration must be: %lu dimension", joint_handles_.size());
     }
-  else if ((int)msg->data.size() != joint_handles_.size()) {
-    ROS_ERROR("Posture message had the wrong size: %d", (int)msg->data.size());
-    return;
+    else if ((int)msg->data.size() != joint_handles_.size()) {
+        ROS_ERROR("Posture message had the wrong size: %d", (int)msg->data.size());
+        return;
     }
-  else
-  {
-    for (unsigned int j = 0; j < joint_handles_.size(); ++j)
-    q_des_(j) = msg->data[j];
-  }
-
-  }
-
-void JointImpedanceController::setGains(const std_msgs::Float64MultiArray::ConstPtr &msg){
-
-  if (msg->data.size() == 2*joint_handles_.size()){
-    for (unsigned int i = 0; i < joint_handles_.size(); ++i){
-      K_(i) = msg->data[i];
-      D_(i)= msg->data[i + joint_handles_.size()];
-      }
-    // for (unsigned int i = joint_handles_.size(); i < 2*joint_handles_.size(); ++i){
-      // 	D_(i)= msg->data[i];
-      // }
+    else
+    {
+        for (unsigned int j = 0; j < joint_handles_.size(); ++j)
+            q_des_(j) = msg->data[j];
     }
-  else
-  {
-    ROS_INFO("Num of Joint handles = %lu", joint_handles_.size());
-  }
+    
+}
 
-  ROS_INFO("Num of Joint handles = %lu, dimension of message = %lu", joint_handles_.size(), msg->data.size());
-
-  ROS_INFO("New gains K: %.1lf, %.1lf, %.1lf %.1lf, %.1lf, %.1lf, %.1lf",
-  K_(0), K_(1), K_(2), K_(3), K_(4), K_(5), K_(6));
-  ROS_INFO("New gains D: %.1lf, %.1lf, %.1lf %.1lf, %.1lf, %.1lf, %.1lf",
-  D_(0), D_(1), D_(2), D_(3), D_(4), D_(5), D_(6));
-
-  }
-
-
-}                                                           // namespace
+void JointImpedanceController::setParam(const std_msgs::Float64MultiArray::ConstPtr& msg, KDL::JntArray& array, std::string s)
+{
+    if (msg->data.size() == joint_handles_.size())
+    {
+        for (unsigned int i = 0; i < joint_handles_.size(); ++i)
+        {
+            array(i) = msg->data[i];
+        }
+    }
+    else
+    {
+        ROS_INFO("Num of Joint handles = %lu", joint_handles_.size());
+    }
+    
+    ROS_INFO("Num of Joint handles = %lu, dimension of message = %lu", joint_handles_.size(), msg->data.size());
+    
+    ROS_INFO("New param %s: %.2lf, %.2lf, %.2lf %.2lf, %.2lf, %.2lf, %.2lf", s.c_str(),
+             array(0), array(1), array(2), array(3), array(4), array(5), array(6));
+    
+}
+    
+} // namespace
 
 PLUGINLIB_EXPORT_CLASS( lwr_controllers::JointImpedanceController, controller_interface::ControllerBase)

--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -9,7 +9,7 @@
 #include <lwr_controllers/joint_impedance_controller.h>
 
 namespace lwr_controllers {
-    
+
 JointImpedanceController::JointImpedanceController() {}
 
 JointImpedanceController::~JointImpedanceController() {}
@@ -18,63 +18,69 @@ bool JointImpedanceController::init(hardware_interface::EffortJointInterface *ro
 {
     KinematicChainControllerBase<hardware_interface::EffortJointInterface>::init(robot, n);
     K_.resize(kdl_chain_.getNrOfJoints());
-    D_.resize(kdl_chain_.getNrOfJoints());
-    
+    D_.resize(kdl_chain_.getNrOfJoints());   
+    q_des_.resize(kdl_chain_.getNrOfJoints());
+    tau_des_.resize(kdl_chain_.getNrOfJoints());
+ 
+    for (size_t i = 0; i < joint_handles_.size(); i++)
+    {
+        tau_des_(i) = joint_handles_[i].getPosition();
+        K_(i) = joint_stiffness_handles_[i].getPosition();
+        D_(i) = joint_damping_handles_[i].getPosition();
+        q_des_(i) = joint_set_point_handles_[i].getPosition();
+    }
+
     ROS_DEBUG(" Number of joints in handle = %lu", joint_handles_.size() );
-    
-    for (int i = 0; i < joint_handles_.size(); ++i){
-        if ( !nh_.getParam("stiffness_gains", K_(i) ) ){
+
+    for (int i = 0; i < joint_handles_.size(); ++i) {
+        if ( !nh_.getParam("stiffness_gains", K_(i) ) ) {
             ROS_WARN("Stiffness gain not set in yaml file, Using %f", K_(i));
         }
     }
-    for (int i = 0; i < joint_handles_.size(); ++i){
-        if ( !nh_.getParam("damping_gains", D_(i)) ){
+    for (int i = 0; i < joint_handles_.size(); ++i) {
+        if ( !nh_.getParam("damping_gains", D_(i)) ) {
             ROS_WARN("Damping gain not set in yaml file, Using %f", D_(i));
         }
     }
-    
-    q_des_.resize(kdl_chain_.getNrOfJoints());
-    tau_des_.resize(kdl_chain_.getNrOfJoints());
+
     typedef  const std_msgs::Float64MultiArray::ConstPtr& msg_type;
     sub_stiffness_ = nh_.subscribe<JointImpedanceController, msg_type>("stiffness", 1, boost::bind(&JointImpedanceController::setParam, this, _1, K_, "K"));
     sub_damping_ = nh_.subscribe<JointImpedanceController, msg_type>("damping", 1, boost::bind(&JointImpedanceController::setParam, this, _1, D_, "D"));
     sub_add_torque_ = nh_.subscribe<JointImpedanceController, msg_type>("additional_torque", 1, boost::bind(&JointImpedanceController::setParam, this, _1, tau_des_, "AddTorque"));
     sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::command, this);
-    
+
     return true;
-    
-    
+
+
 }
 
 void JointImpedanceController::starting(const ros::Time& time)
 {
     // Initializing stiffness, damping, ext_torque and set point values
-    for(size_t i=0; i<joint_handles_.size(); i++) {
-        K_(i) = 300.0;
-        D_(i) = 0.7;
+    for (size_t i = 0; i < joint_handles_.size(); i++) {
         tau_des_(i) = 0.0;
-        q_des_(i) =joint_handles_[i].getPosition();
+        q_des_(i) = joint_handles_[i].getPosition();
     }
-    
-    
+
+
 }
 
 void JointImpedanceController::update(const ros::Time& time, const ros::Duration& period)
 {
-    
+
     //Compute control law. This controller sets all variables for the JointImpedance Interface from kuka
-    for(size_t i=0; i<joint_handles_.size(); i++) 
+    for (size_t i = 0; i < joint_handles_.size(); i++)
     {
         joint_handles_[i].setCommand(tau_des_(i));
         joint_stiffness_handles_[i].setCommand(K_(i));
         joint_damping_handles_[i].setCommand(D_(i));
         joint_set_point_handles_[i].setCommand(q_des_(i));
-    }   
-    
+    }
+
 }
 
 
-void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstPtr &msg){
+void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstPtr &msg) {
     if (msg->data.size() == 0) {
         ROS_INFO("Desired configuration must be: %lu dimension", joint_handles_.size());
     }
@@ -87,7 +93,7 @@ void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstP
         for (unsigned int j = 0; j < joint_handles_.size(); ++j)
             q_des_(j) = msg->data[j];
     }
-    
+
 }
 
 void JointImpedanceController::setParam(const std_msgs::Float64MultiArray::ConstPtr& msg, KDL::JntArray& array, std::string s)
@@ -103,14 +109,14 @@ void JointImpedanceController::setParam(const std_msgs::Float64MultiArray::Const
     {
         ROS_INFO("Num of Joint handles = %lu", joint_handles_.size());
     }
-    
+
     ROS_INFO("Num of Joint handles = %lu, dimension of message = %lu", joint_handles_.size(), msg->data.size());
-    
+
     ROS_INFO("New param %s: %.2lf, %.2lf, %.2lf %.2lf, %.2lf, %.2lf, %.2lf", s.c_str(),
              array(0), array(1), array(2), array(3), array(4), array(5), array(6));
-    
+
 }
-    
+
 } // namespace
 
 PLUGINLIB_EXPORT_CLASS( lwr_controllers::JointImpedanceController, controller_interface::ControllerBase)

--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -44,9 +44,9 @@ bool JointImpedanceController::init(hardware_interface::EffortJointInterface *ro
     }
 
     typedef  const std_msgs::Float64MultiArray::ConstPtr& msg_type;
-    sub_stiffness_ = nh_.subscribe<JointImpedanceController, msg_type>("stiffness", 1, boost::bind(&JointImpedanceController::setParam, this, _1, K_, "K"));
-    sub_damping_ = nh_.subscribe<JointImpedanceController, msg_type>("damping", 1, boost::bind(&JointImpedanceController::setParam, this, _1, D_, "D"));
-    sub_add_torque_ = nh_.subscribe<JointImpedanceController, msg_type>("additional_torque", 1, boost::bind(&JointImpedanceController::setParam, this, _1, tau_des_, "AddTorque"));
+    sub_stiffness_ = nh_.subscribe<JointImpedanceController, msg_type>("stiffness", 1, boost::bind(&JointImpedanceController::setParam, this, _1, &K_, "K"));
+    sub_damping_ = nh_.subscribe<JointImpedanceController, msg_type>("damping", 1, boost::bind(&JointImpedanceController::setParam, this, _1, &D_, "D"));
+    sub_add_torque_ = nh_.subscribe<JointImpedanceController, msg_type>("additional_torque", 1, boost::bind(&JointImpedanceController::setParam, this, _1, &tau_des_, "AddTorque"));
     sub_posture_ = nh_.subscribe("command", 1, &JointImpedanceController::command, this);
 
     return true;
@@ -96,13 +96,13 @@ void JointImpedanceController::command(const std_msgs::Float64MultiArray::ConstP
 
 }
 
-void JointImpedanceController::setParam(const std_msgs::Float64MultiArray::ConstPtr& msg, KDL::JntArray& array, std::string s)
+void JointImpedanceController::setParam(const std_msgs::Float64MultiArray_< std::allocator< void > >::ConstPtr& msg, KDL::JntArray* array, std::string s)
 {
     if (msg->data.size() == joint_handles_.size())
     {
         for (unsigned int i = 0; i < joint_handles_.size(); ++i)
         {
-            array(i) = msg->data[i];
+            (*array)(i) = msg->data[i];
         }
     }
     else
@@ -113,8 +113,7 @@ void JointImpedanceController::setParam(const std_msgs::Float64MultiArray::Const
     ROS_INFO("Num of Joint handles = %lu, dimension of message = %lu", joint_handles_.size(), msg->data.size());
 
     ROS_INFO("New param %s: %.2lf, %.2lf, %.2lf %.2lf, %.2lf, %.2lf, %.2lf", s.c_str(),
-             array(0), array(1), array(2), array(3), array(4), array(5), array(6));
-
+             (*array)(0), (*array)(1), (*array)(2), (*array)(3), (*array)(4), (*array)(5), (*array)(6));
 }
 
 } // namespace

--- a/lwr_hw/include/fri/friremote.h
+++ b/lwr_hw/include/fri/friremote.h
@@ -163,7 +163,10 @@ public:
 		/** KRL Interaction -- Corresponds to $FRI_TO_INT */
 	int   getFrmKRLInt(int index) { return msr.krl.intData[index]; }
 		/** KRL Interaction -- Corresponds to $FRI_FRM_INT */
-	void  setToKRLInt(int index, int val) { cmd.krl.intData[index]=val; }
+	void  setToKRLInt(int index, int val) { cmd.krl.intData[index]=val; 
+		if (index == 0)
+			cmd.cmd.cmdFlags = 0;
+	}
 		/** KRL Interaction -- Corresponds to $FRI_TO_BOOL */
 	bool  getFrmKRLBool(int index) { return ((msr.krl.boolData & (1<<index)) != 0);}
 		/** KRL Interaction -- Corresponds to $FRI_FRM_BOOL */

--- a/lwr_hw/include/lwr_hw/lwr_hw.h
+++ b/lwr_hw/include/lwr_hw/lwr_hw.h
@@ -117,6 +117,7 @@ public:
   joint_stiffness_,
   joint_damping_,
   joint_position_command_,
+  joint_set_point_command_,
   joint_velocity_command_,
   joint_stiffness_command_,
   joint_damping_command_,

--- a/lwr_hw/include/lwr_hw/lwr_hw.h
+++ b/lwr_hw/include/lwr_hw/lwr_hw.h
@@ -163,15 +163,7 @@ private:
   bool initKDLdescription(const urdf::Model *const urdf_model);
 
   // Helper function to register limit interfaces
-  void registerJointLimits(const std::string& joint_name,
-                   const hardware_interface::JointHandle& joint_handle_effort,
-                   const hardware_interface::JointHandle& joint_handle_position,
-                   const hardware_interface::JointHandle& joint_handle_velocity,
-                   const hardware_interface::JointHandle& joint_handle_stiffness,
-                   const urdf::Model *const urdf_model,
-                   double *const lower_limit, double *const upper_limit,
-                   double *const lower_limit_stiffness, double *const upper_limit_stiffness,
-                   double *const effort_limit);
+  void registerJointLimits(const std::string& joint_name, const hardware_interface::JointHandle& joint_handle_effort, const hardware_interface::JointHandle& joint_handle_position, const hardware_interface::JointHandle& joint_handle_velocity, const hardware_interface::JointHandle& joint_handle_stiffness, const hardware_interface::JointHandle& joint_handle_damping, const urdf::Model*const urdf_model, double*const effort_limit, double*const lower_limit, double*const upper_limit, double*const lower_limit_stiffness, double*const upper_limit_stiffness, double*const lower_limit_damping, double*const upper_limit_damping);
 
 }; // class
 

--- a/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
@@ -131,7 +131,7 @@ public:
       case JOINT_IMPEDANCE:
         for(int j=0; j < n_joints_; j++)
         {
-          newJntPosition[j] = joint_position_command_[j];
+          newJntPosition[j] = joint_set_point_command_[j];
           newJntAddTorque[j] = joint_effort_command_[j];
           newJntStiff[j] = joint_stiffness_command_[j];
           newJntDamp[j] = joint_damping_command_[j];
@@ -152,7 +152,7 @@ public:
       case JOINT_STIFFNESS:
         for(int j=0; j < n_joints_; j++)
         {
-          newJntPosition[j] = joint_position_command_[j];
+          newJntPosition[j] = joint_set_point_command_[j];
           newJntStiff[j] = joint_stiffness_command_[j];
         }
         device_->doJntImpedanceControl(newJntPosition, newJntStiff, NULL, NULL, false);

--- a/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
@@ -77,6 +77,7 @@ public:
       joint_effort_[j] = device_->getMsrJntTrq()[j];
       joint_velocity_[j] = filters::exponentialSmoothing((joint_position_[j]-joint_position_prev_[j])/period.toSec(), joint_velocity_[j], 0.2);
       joint_stiffness_[j] = joint_stiffness_command_[j];
+      joint_damping_[j] = joint_damping_command_[j];
     }
     for(int j = 0; j < 12; j++)
     {

--- a/lwr_hw/include/lwr_hw/lwr_hw_fril.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fril.hpp
@@ -118,7 +118,7 @@ public:
 
             for(int j=0; j < n_joints_; j++)
             {
-              newJntPosition[j] = (float)joint_position_command_[j];
+              newJntPosition[j] = (float)joint_set_point_command_[j];
               newJntAddTorque[j] = (float)joint_effort_command_[j];
               newJntStiff[j] = (float)joint_stiffness_command_[j];
               newJntDamp[j] = (float)joint_damping_command_[j];

--- a/lwr_hw/include/lwr_hw/lwr_hw_fril.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fril.hpp
@@ -66,6 +66,7 @@ public:
       joint_effort_[j] = (double)msrJntTrq[j];
       joint_velocity_[j] = filters::exponentialSmoothing((joint_position_[j]-joint_position_prev_[j])/period.toSec(), joint_velocity_[j], 0.2);
       joint_stiffness_[j] = joint_stiffness_command_[j];
+      joint_damping_[j] = joint_damping_command_[j];
     }
     return;
   }

--- a/lwr_hw/src/fri/friremote.cpp
+++ b/lwr_hw/src/fri/friremote.cpp
@@ -153,7 +153,7 @@ int friRemote::doJntImpedanceControl(const float newJntPosition[LBR_MNJ],
 
 {
 	// Helper, if not properly initialized or the like...
-	cmd.cmd.cmdFlags=0;
+	//cmd.cmd.cmdFlags=0;    
 	if (newJntPosition)
 	{
 		cmd.cmd.cmdFlags|=FRI_CMD_JNTPOS;

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -205,6 +205,13 @@ namespace lwr_hw
       joint_handle_position = hardware_interface::JointHandle(state_interface_.getHandle(joint_names_[j]),
                                                        &joint_position_command_[j]);
       position_interface_.registerHandle(joint_handle_position);
+      
+      hardware_interface::JointHandle joint_handle_set_point;
+      joint_handle_set_point = hardware_interface::JointHandle(hardware_interface::JointStateHandle(
+                                                                   joint_names_[j]+std::string("_set_point"),
+                                                                   &joint_position_[j], &joint_velocity_[j], &joint_effort_[j]),
+                                                       &joint_position_command_[j]);
+      effort_interface_.registerHandle(joint_handle_set_point);
 
       // the stiffness is not actually a different joint, so the state handle is only used for handle
       hardware_interface::JointHandle joint_handle_stiffness;
@@ -212,7 +219,16 @@ namespace lwr_hw
                                                                    joint_names_[j]+std::string("_stiffness"),
                                                                    &joint_stiffness_[j], &joint_stiffness_[j], &joint_stiffness_[j]),
                                                        &joint_stiffness_command_[j]);
-      position_interface_.registerHandle(joint_handle_stiffness);
+      // FIXME: This interface is not working properly. It was relaying on an old ros_control fork already deprecated.
+      //position_interface_.registerHandle(joint_handle_stiffness);
+      effort_interface_.registerHandle(joint_handle_stiffness);
+      
+      hardware_interface::JointHandle joint_handle_damping;
+      joint_handle_damping = hardware_interface::JointHandle(hardware_interface::JointStateHandle(
+                                                                    joint_names_[j]+std::string("_damping"),  
+                                                                    &joint_damping_[j], &joint_damping_[j], &joint_damping_[j]),
+                                                                    &joint_damping_command_[j]);
+      effort_interface_.registerHandle(joint_handle_damping);
    
      // velocity command handle, recall it is fake, there is no actual velocity interface
       hardware_interface::JointHandle joint_handle_velocity;

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -106,8 +106,8 @@ namespace lwr_hw
       joint_position_command_[j] = 0.0;
       joint_velocity_command_[j] = 0.0;
       joint_effort_command_[j] = 0.0;
-      joint_stiffness_command_[j] = 2500.0;
-      joint_damping_command_[j] = 0.0;
+      joint_stiffness_command_[j] = 1000.0;
+      joint_damping_command_[j] = 0.7;
     }
 
     for(int i=0; i < 12; ++i)

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -223,7 +223,6 @@ namespace lwr_hw
                                                                    joint_names_[j]+std::string("_stiffness"),
                                                                    &joint_stiffness_[j], &joint_stiffness_[j], &joint_stiffness_[j]),
                                                        &joint_stiffness_command_[j]);
-      // FIXME: This interface is not working properly. It was relaying on an old ros_control fork already deprecated.
       //position_interface_.registerHandle(joint_handle_stiffness);
       effort_interface_.registerHandle(joint_handle_stiffness);
       

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -47,6 +47,7 @@ namespace lwr_hw
     joint_stiffness_.resize(n_joints_);
     joint_damping_.resize(n_joints_);
     joint_position_command_.resize(n_joints_);
+    joint_set_point_command_.resize(n_joints_);
     joint_velocity_command_.resize(n_joints_);
     joint_effort_command_.resize(n_joints_);
     joint_stiffness_command_.resize(n_joints_);
@@ -104,6 +105,7 @@ namespace lwr_hw
       joint_damping_[j] = 0.0;
 
       joint_position_command_[j] = 0.0;
+      joint_set_point_command_[j] = 0.0;
       joint_velocity_command_[j] = 0.0;
       joint_effort_command_[j] = 0.0;
       joint_stiffness_command_[j] = 1000.0;
@@ -210,7 +212,7 @@ namespace lwr_hw
       joint_handle_set_point = hardware_interface::JointHandle(hardware_interface::JointStateHandle(
                                                                    joint_names_[j]+std::string("_set_point"),
                                                                    &joint_position_[j], &joint_velocity_[j], &joint_effort_[j]),
-                                                       &joint_position_command_[j]);
+                                                       &joint_set_point_command_[j]);
       effort_interface_.registerHandle(joint_handle_set_point);
 
       // the stiffness is not actually a different joint, so the state handle is only used for handle

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -65,6 +65,8 @@ namespace lwr_hw
     joint_upper_limits_.resize(n_joints_);
     joint_lower_limits_stiffness_.resize(n_joints_);
     joint_upper_limits_stiffness_.resize(n_joints_);
+    joint_upper_limits_damping_.resize(n_joints_);
+    joint_lower_limits_damping_.resize(n_joints_);
     joint_effort_limits_.resize(n_joints_);
 
     // RESET VARIABLES
@@ -242,11 +244,14 @@ namespace lwr_hw
                           joint_handle_position,
                           joint_handle_velocity,
                           joint_handle_stiffness,
+                          joint_handle_damping,
                           urdf_model, 
+                          &joint_effort_limits_[j],
                           &joint_lower_limits_[j], &joint_upper_limits_[j],
                           &joint_lower_limits_stiffness_[j],
                           &joint_upper_limits_stiffness_[j],
-                          &joint_effort_limits_[j]);
+                          &joint_lower_limits_damping_[j],
+                          &joint_upper_limits_damping_[j]);
     }
 
     // Now for cart variables
@@ -294,26 +299,24 @@ namespace lwr_hw
   // Register the limits of the joint specified by joint_name and\ joint_handle. The limits are
   // retrieved from the urdf_model.
   // Return the joint's type, lower position limit, upper position limit, and effort limit.
-  void LWRHW::registerJointLimits(const std::string& joint_name,
-                           const hardware_interface::JointHandle& joint_handle_effort,
-                           const hardware_interface::JointHandle& joint_handle_position,
-                           const hardware_interface::JointHandle& joint_handle_velocity,
-                           const hardware_interface::JointHandle& joint_handle_stiffness,
-                           const urdf::Model *const urdf_model,
-                           double *const lower_limit, double *const upper_limit, 
-                           double *const lower_limit_stiffness, double *const upper_limit_stiffness,
-                           double *const effort_limit)
-  {
+  // TODO: register limits for cartesian variables
+
+  void LWRHW::registerJointLimits(const std::string& joint_name, const hardware_interface::JointHandle& joint_handle_effort, const hardware_interface::JointHandle& joint_handle_position, const hardware_interface::JointHandle& joint_handle_velocity, const hardware_interface::JointHandle& joint_handle_stiffness,  const hardware_interface::JointHandle& joint_handle_damping, const urdf::Model*const urdf_model, double*const effort_limit, double*const lower_limit, double*const upper_limit, double*const lower_limit_stiffness, double*const upper_limit_stiffness, double*const lower_limit_damping, double*const upper_limit_damping)
+{
     *lower_limit = -std::numeric_limits<double>::max();
     *upper_limit = std::numeric_limits<double>::max();
     *lower_limit_stiffness = -std::numeric_limits<double>::max();
     *upper_limit_stiffness = std::numeric_limits<double>::max();
+    *lower_limit_damping = -std::numeric_limits<double>::max();
+    *upper_limit_damping = std::numeric_limits<double>::max();
     *effort_limit = std::numeric_limits<double>::max();
 
     joint_limits_interface::JointLimits limits;
     joint_limits_interface::JointLimits limits_stiffness;
+    joint_limits_interface::JointLimits limits_damping;
     bool has_limits = false;
     bool has_limits_stiffness = false;
+    bool has_limits_damping = false;
     joint_limits_interface::SoftJointLimits soft_limits;
     bool has_soft_limits = false;
 
@@ -321,6 +324,7 @@ namespace lwr_hw
     {
       const boost::shared_ptr<const urdf::Joint> urdf_joint = urdf_model->getJoint(joint_name);
       const boost::shared_ptr<const urdf::Joint> urdf_joint_sitffness = urdf_model->getJoint(joint_name + std::string("_stiffness"));
+      const boost::shared_ptr<const urdf::Joint> urdf_joint_damping = urdf_model->getJoint(joint_name + std::string("_damping"));
       if (urdf_joint != NULL)
       {
         // Get limits from the URDF file.
@@ -328,6 +332,8 @@ namespace lwr_hw
           has_limits = true;
         if (joint_limits_interface::getJointLimits(urdf_joint_sitffness, limits_stiffness))
           has_limits_stiffness = true;
+        if (joint_limits_interface::getJointLimits(urdf_joint_damping, limits_damping))
+            has_limits_damping = true;
         if (joint_limits_interface::getSoftJointLimits(urdf_joint, soft_limits))
           has_soft_limits = true;
       }
@@ -364,17 +370,28 @@ namespace lwr_hw
       vj_sat_interface_.registerHandle(sat_handle_velocity);
     }
 
-    if (!has_limits_stiffness)
-      return;
-
-    if (limits_stiffness.has_position_limits)
+    if (has_limits_stiffness)
     {
-      *lower_limit_stiffness = limits_stiffness.min_position;
-      *upper_limit_stiffness = limits_stiffness.max_position;
-    }
 
-    const joint_limits_interface::PositionJointSaturationHandle sat_handle_stiffness(joint_handle_stiffness, limits_stiffness);
-    sj_sat_interface_.registerHandle(sat_handle_stiffness);
+        if (limits_stiffness.has_position_limits)
+        {
+        *lower_limit_stiffness = limits_stiffness.min_position;
+        *upper_limit_stiffness = limits_stiffness.max_position;
+        }
+        const joint_limits_interface::PositionJointSaturationHandle sat_handle_stiffness(joint_handle_stiffness, limits_stiffness);
+        sj_sat_interface_.registerHandle(sat_handle_stiffness);
+    }
+    if (has_limits_damping)
+    {
+        
+        if (limits_damping.has_position_limits)
+        {
+            *lower_limit_damping = limits_damping.min_position;
+            *upper_limit_damping = limits_damping.max_position;
+        }
+        const joint_limits_interface::PositionJointSaturationHandle sat_handle_damping(joint_handle_damping, limits_damping);
+        dj_sat_interface_.registerHandle(sat_handle_damping);
+    }
   }
 
   void LWRHW::enforceLimits(ros::Duration period)


### PR DESCRIPTION
The [`JointImpedanceController`](https://github.com/CentroEPiaggio/kuka-lwr/blob/master/lwr_controllers/src/joint_impedance_controller.cpp) is at now internally computing the torque based on stiffness and damping, while it could actually use the internal `JOINT_IMPEDANCE` interface of the KRC.
This PR address such change, while also working on [resetting appropriately the flags when the command mode is changed](https://github.com/CentroEPiaggio/kuka-lwr/commit/a672937091e6889031a77e428f77e796f8892d7e#diff-c71249cd19d761a5a4973561add077beR166), so that it is possible to switch between different control modes back and forth without incurring in various errors (as also commented in #67).