### PR TITLE
Numerical mass matrix from FRI

### DIFF
--- a/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
+++ b/lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
@@ -50,6 +50,7 @@ namespace controller_interface
         std::vector<typename JI::ResourceHandleType> joint_stiffness_handles_;
         std::vector<typename JI::ResourceHandleType> joint_damping_handles_;
         std::vector<typename JI::ResourceHandleType> joint_set_point_handles_;
+	std::vector<typename JI::ResourceHandleType> inertia_matrix_handles_;
         
         bool getHandles(JI *robot);
         

--- a/lwr_controllers/src/KinematicChainControllerBase.cpp
+++ b/lwr_controllers/src/KinematicChainControllerBase.cpp
@@ -16,6 +16,13 @@ bool KinematicChainControllerBase<hardware_interface::EffortJointInterface>::get
 	        ROS_DEBUG("%s", it->getJoint().getName().c_str() );
 	    }
     }
+
+    // Inertia matrix handles
+    int n_joints = 7;
+    for (int i=0; i<n_joints; i++)
+      for (int j=0; j<n_joints; j++)
+	inertia_matrix_handles_.push_back(robot->getHandle("inertia_" + std::to_string(i) + "_" + std::to_string(j)));
+
     return true;
 }
 }

--- a/lwr_hw/include/fri/friremote.h
+++ b/lwr_hw/include/fri/friremote.h
@@ -150,6 +150,7 @@ public:
 	float * getMsrMsrJntPosition() { return msr.data.msrJntPos; }
 	float * getMsrEstExtJntTrq() { return msr.data.estExtJntTrq; }
 	float * getMsrJntTrq() { return msr.data.msrJntTrq; }
+	float * getMsrMassMatrix() { return msr.data.massMatrix;}
 		/* @} */
 
 	float getSampleTime() { return msr.intf.desiredCmdSampleTime; }

--- a/lwr_hw/include/lwr_hw/lwr_hw.h
+++ b/lwr_hw/include/lwr_hw/lwr_hw.h
@@ -26,6 +26,7 @@
 #include <kdl/chaindynparam.hpp> //this to compute the gravity verctor
 #include <kdl_parser/kdl_parser.hpp>
 
+
 namespace lwr_hw
 {
 
@@ -144,7 +145,9 @@ public:
   cart_pos_command_,
   cart_stiff_command_,
   cart_damp_command_,
-  cart_wrench_command_;
+  cart_wrench_command_,
+  inertia_matrix_,
+  inertia_matrix_fake_;
 
   // NOTE:
   // joint_velocity_command is not really to command the kuka arm in velocity,

--- a/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
+++ b/lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
@@ -89,6 +89,9 @@ public:
         cart_damp_[j] = cart_damp_command_[j];
         cart_wrench_[j] = cart_wrench_command_[j];
     }
+    for (int j = 0; j < n_joints_ * n_joints_; j++)
+      inertia_matrix_[j] = device_->getMsrMassMatrix()[j];
+
     return;
   }
 

--- a/lwr_hw/src/lwr_hw.cpp
+++ b/lwr_hw/src/lwr_hw.cpp
@@ -60,6 +60,8 @@ namespace lwr_hw
     cart_stiff_command_.resize(6);
     cart_damp_command_.resize(6);
     cart_wrench_command_.resize(6);
+    inertia_matrix_.resize(n_joints_ * n_joints_);
+    inertia_matrix_fake_.resize(n_joints_ * n_joints_);
 
     joint_lower_limits_.resize(n_joints_);
     joint_upper_limits_.resize(n_joints_);
@@ -286,6 +288,18 @@ namespace lwr_hw
                                                        &cart_wrench_command_[j]);
       position_cart_interface_.registerHandle(cart_wrench_handle);
     }
+
+    for (int i=0; i< n_joints_; i++)
+      for (int j=0; j< n_joints_; j++)
+	{
+	hardware_interface::JointHandle inertia_handle_ij;
+	inertia_handle_ij = hardware_interface::JointHandle(hardware_interface::JointStateHandle(
+                            "inertia_" + std::to_string(i) + "_" + std::to_string(j),
+                            &inertia_matrix_[i*7 + j], &inertia_matrix_[i*7 + j], &inertia_matrix_[i*7 + j]),
+			    &inertia_matrix_fake_[i*7 + j]);
+	effort_interface_.registerHandle(inertia_handle_ij);
+      }
+
 
     // Register interfaces
     registerInterface(&state_interface_);


### PR DESCRIPTION
As reported in the KUKA.FastResearchInterface 1.0 manual it is possible to obtain the numerical mass matrix, i.e. joint space inertia matrix.

In order to obtain the matrix in controllers implementing the class KinematicChainControllerBase<hardware_interface::EffortJointInterface>
- a function **getMsrMassMatrix()** is added in lwr_hw/include/fri/friremote.h that returns a pointer to the numerical mass matrix
- the function getMsrMassMatrix() is called in the method read() in lwr_hw/include/lwr_hw/lwr_hw_fri.hpp
- 7x7 handles are registered in the already existent **effort_interface_** in lwr_hw/src/lwr_hw.cpp so that
handles can be obtained back in KinematicChainControllerBase
- a new handle **inertia_matrix_handles** is created in lwr_controllers/include/lwr_controllers/KinematicChainControllerBase.h
and populated in lwr_controllers/src/KinematicChainControllerBase.cpp