### PR TITLE
Do not initialize position with torque in impedance controller

### DIFF
--- a/lwr_controllers/src/joint_impedance_controller.cpp
+++ b/lwr_controllers/src/joint_impedance_controller.cpp
@@ -59,7 +59,7 @@ void JointImpedanceController::starting(const ros::Time& time)
     // Initializing stiffness, damping, ext_torque and set point values
     for (size_t i = 0; i < joint_handles_.size(); i++) {
         tau_des_(i) = 0.0;
-        q_des_(i) = joint_handles_[i].getPosition();
+        q_des_(i) = joint_set_point_handles_[i].getPosition();
     }
 
 


### PR DESCRIPTION
Since the impedance controller is an EffortController, joint_handles are torque handles; joint_set_point_handles are the position handles.

Initializing the position with the torque (at start probably all zeros) could explain a lot of FRI interpolation errors at startup.