### PR TITLE
Modify computed torque control algorithm

### DIFF
--- a/lwr_controllers/src/computed_torque_controller.cpp
+++ b/lwr_controllers/src/computed_torque_controller.cpp
@@ -105,7 +105,7 @@ namespace lwr_controllers
         {
             // control law
             pid_cmd_(i) = joint_des_states_.qdotdot(i) + Kv_(i)*(joint_des_states_.qdot(i) - joint_msr_states_.qdot(i)) + Kp_(i)*(joint_des_states_.q(i) - joint_msr_states_.q(i));
-            cg_cmd_(i) = C_(i)*joint_msr_states_.qdot(i) + G_(i);
+            cg_cmd_(i) = C_(i) + G_(i);
         }
         tau_cmd_.data = M_.data * pid_cmd_.data;
         KDL::Add(tau_cmd_,cg_cmd_,tau_cmd_);


### PR DESCRIPTION
Modify Coriolis compensation term.
KDL Coriolis term is not matrix but vector already multiplied by joint velocity.